### PR TITLE
Implement initial bootloader and kernel entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# Unix-Optrix
+# OptrixOS
+
+This project experiments with building a small Unix-like operating system. The
+initial bootloader is written in NASM and performs the following steps:
+
+- Loads the kernel from the disk image into memory at `0x1000`.
+- Initializes a simple GDT and switches the CPU to 32-bit protected mode.
+- Jumps to the kernel entry point.
+
+Use `python3 setup_bootloader.py` to assemble and link the boot files. The
+script requires `nasm`, `gcc` with 32-bit support, and `ld`.

--- a/bootloader.asm
+++ b/bootloader.asm
@@ -1,0 +1,70 @@
+; Bootloader for OptrixOS
+[org 0x7c00]
+[bits 16]
+
+global boot
+boot:
+    cli
+    mov [BOOT_DRIVE], dl
+    xor ax, ax
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+    mov sp, 0x7c00
+    sti
+
+    ; load kernel (one sector) to 0x1000
+    mov bx, 0x1000
+    mov dh, 0
+    mov dl, [BOOT_DRIVE]
+    mov ah, 0x02
+    mov al, 1
+    mov ch, 0
+    mov cl, 2
+    int 0x13
+    jc disk_error
+
+    ; setup GDT for protected mode
+    cli
+    lgdt [GDT_DESC]
+    mov eax, cr0
+    or eax, 1
+    mov cr0, eax
+    jmp CODE_SEG:init_pm
+
+; 32-bit code
+[bits 32]
+init_pm:
+    mov ax, DATA_SEG
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
+    mov esp, 0x9fc00
+    jmp CODE_SEG:0x1000
+
+[bits 16]
+disk_error:
+    hlt
+    jmp disk_error
+
+BOOT_DRIVE db 0
+
+; GDT entries
+align 4
+GDT:
+    dq 0
+CODE_SEG equ 0x08
+DATA_SEG equ 0x10
+    dq 0x00cf9a000000ffff ; code segment
+    dq 0x00cf92000000ffff ; data segment
+GDT_END:
+
+; GDT descriptor
+GDT_DESC:
+    dw GDT_END - GDT - 1
+    dd GDT
+
+times 510 - ($-$$) db 0
+DW 0xAA55

--- a/kernel.asm
+++ b/kernel.asm
@@ -1,0 +1,10 @@
+[bits 32]
+
+global start
+extern kernel_main
+
+start:
+    call kernel_main
+.hang:
+    hlt
+    jmp .hang

--- a/kernel_main.c
+++ b/kernel_main.c
@@ -1,0 +1,6 @@
+void kernel_main(void) {
+    char *video = (char*)0xb8000;
+    video[0] = 'O';
+    video[1] = 0x07;
+    for(;;);
+}


### PR DESCRIPTION
## Summary
- add a simple NASM bootloader that loads the kernel and switches to 32‑bit mode
- provide minimal 32‑bit kernel skeleton and C entry
- clean up README with build notes

## Testing
- `python3 setup_bootloader.py` *(fails: Error: Required file not found: idt.asm)*

------
https://chatgpt.com/codex/tasks/task_e_684daa41850c832f8c75610e1fe2bec9