### PR TITLE
Add simple Optrix kernel build

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,5 @@ initial bootloader is written in NASM and performs the following steps:
 - Jumps to the kernel entry point.
 
 Use `python3 setup_bootloader.py` to assemble and link the boot files. The
-script requires `nasm`, `gcc` with 32-bit support, and `ld`.
+script builds a small custom kernel located in `optrix_kernel/` and produces
+`optrix-kernel.bin`. It requires `nasm`, `gcc` with 32-bit support, and `ld`.

--- a/optrix_kernel/entry.asm
+++ b/optrix_kernel/entry.asm
@@ -1,0 +1,10 @@
+[bits 32]
+
+global start
+extern kmain
+
+start:
+    call kmain
+.hang:
+    hlt
+    jmp .hang

--- a/optrix_kernel/kmain.c
+++ b/optrix_kernel/kmain.c
@@ -1,0 +1,9 @@
+void kmain(void) {
+    const char *msg = "Optrix kernel loaded";
+    char *video = (char*)0xb8000;
+    for (int i = 0; msg[i]; i++) {
+        video[i*2] = msg[i];
+        video[i*2 + 1] = 0x07;
+    }
+    for(;;);
+}

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -24,22 +24,11 @@ if not os.path.isfile(MKISOFS_EXE):
 
 asm_files = [
     "bootloader.asm",    # boot sector (must remain first, used for bin)
-    "kernel.asm",        # kernel entry
-    "idt.asm"
+    "optrix_kernel/entry.asm",
 ]
 
 c_files = [
-    "kernel_main.c",
-    "vga.c",
-    "graphics.c",
-    "pmm.c",
-    "vmm.c",
-    "idt.c",
-    "hardware.c",
-    "keyboard.c",
-    "mouse.c",
-    "fabric.c",
-    "font8x8.c"
+    "optrix_kernel/kmain.c",
 ]
 
 tmp_files = []
@@ -158,7 +147,7 @@ def build_kernel(asm_files, c_files, out_bin):
             seen_objs.add(c_obj)
 
     # Link to ELF for debugging (add -e start)
-    kernel_bin = "kernel.bin"
+    kernel_bin = out_bin
     elf_out = kernel_bin.replace(".bin", ".elf")
     print(f"Linking kernel ELF: {elf_out}")
     link_cmd_elf = [LD, "-Ttext", "0x1000", "-m", "elf_i386", "-e", "start", "-nostdlib"] + obj_files + ["-o", elf_out]
@@ -191,7 +180,7 @@ def main():
         check_file(c)
 
     # Build all ASM and C files, get bootloader bin and kernel bin path
-    boot_bin, kernel_bin = build_kernel(asm_files, c_files, out_bin="kernel.bin")
+    boot_bin, kernel_bin = build_kernel(asm_files, c_files, out_bin="optrix-kernel.bin")
 
     # Build floppy image and ISO
     make_dynamic_img(boot_bin, kernel_bin, hd_img)


### PR DESCRIPTION
## Summary
- create `optrix_kernel` with a basic entry stub and kernel main
- update `setup_bootloader.py` to build `optrix-kernel.bin`
- clarify README about new kernel build

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_684dc40c48c0832f90d147b3e156fecc