### PR TITLE
Add bootloader under optrix_kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.bin
+*.o
+*.img
+*.iso

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # OptrixOS
 
 This project experiments with building a small Unix-like operating system. The
-initial bootloader is written in NASM and performs the following steps:
+boot sector is defined in `optrix_kernel/bootloader.asm` and performs the
+following steps:
 
 - Loads the kernel from the disk image into memory at `0x1000`.
 - Initializes a simple GDT and switches the CPU to 32-bit protected mode.

--- a/optrix_kernel/bootloader.asm
+++ b/optrix_kernel/bootloader.asm
@@ -1,0 +1,68 @@
+; Bootloader for OptrixOS (stage1)
+[org 0x7c00]
+[bits 16]
+
+global boot
+boot:
+    cli
+    mov [BOOT_DRIVE], dl
+    xor ax, ax
+    mov ds, ax
+    mov es, ax
+    mov ss, ax
+    mov sp, 0x7c00
+    sti
+
+    ; load kernel from disk (KERNEL_SECTORS sectors) to 0x1000
+    mov bx, 0x1000
+    mov dh, 0
+    mov dl, [BOOT_DRIVE]
+    mov ah, 0x02
+    mov al, KERNEL_SECTORS
+    mov ch, 0
+    mov cl, 2
+    int 0x13
+    jc disk_error
+
+    ; enter protected mode
+    cli
+    lgdt [GDT_DESC]
+    mov eax, cr0
+    or eax, 1
+    mov cr0, eax
+    jmp CODE_SEG:init_pm
+
+[bits 32]
+init_pm:
+    mov ax, DATA_SEG
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
+    mov esp, 0x9fc00
+    jmp CODE_SEG:0x1000
+
+[bits 16]
+disk_error:
+    hlt
+    jmp disk_error
+
+BOOT_DRIVE db 0
+KERNEL_SECTORS equ 4
+
+align 4
+GDT:
+    dq 0
+CODE_SEG equ 0x08
+DATA_SEG equ 0x10
+    dq 0x00cf9a000000ffff
+    dq 0x00cf92000000ffff
+GDT_END:
+
+GDT_DESC:
+    dw GDT_END - GDT - 1
+    dd GDT
+
+times 510-($-$$) db 0
+dw 0xaa55

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -23,7 +23,7 @@ if not os.path.isfile(MKISOFS_EXE):
     MKISOFS_EXE = shutil.which("mkisofs") or "mkisofs"
 
 asm_files = [
-    "bootloader.asm",    # boot sector (must remain first, used for bin)
+    "optrix_kernel/bootloader.asm",    # boot sector (must remain first, used for bin)
     "optrix_kernel/entry.asm",
 ]
 


### PR DESCRIPTION
## Summary
- move boot sector logic into `optrix_kernel/bootloader.asm`
- update build script to assemble the new bootloader
- document bootloader path in README
- add `.gitignore` for build artifacts

## Testing
- `python3 -m py_compile setup_bootloader.py`
- `python3 setup_bootloader.py` *(fails: FileNotFoundError: 'i686-linux-gnu-gcc')*

------
https://chatgpt.com/codex/tasks/task_e_684dce93a468832fa08d5a675439e114