### PR TITLE
Improve bootloader memory init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.bin
+*.o
+*.img
+*.iso

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # OptrixOS
 
 This project experiments with building a small Unix-like operating system. The
-initial bootloader is written in NASM and performs the following steps:
+boot sector lives in `optrix_kernel/bootloader.asm` and performs the
+following steps:
 
+- Copies itself to a safe location at `0x0600` and clears low memory.
 - Loads the kernel from the disk image into memory at `0x1000`.
 - Initializes a simple GDT and switches the CPU to 32-bit protected mode.
 - Jumps to the kernel entry point.
 
 Use `python3 setup_bootloader.py` to assemble and link the boot files. The
 script builds a small custom kernel located in `optrix_kernel/` and produces
-`optrix-kernel.bin`. It requires `nasm`, `gcc` with 32-bit support, and `ld`.
+`optrix-kernel.bin`. It requires `nasm`, `gcc` with 32-bit support, `ld`, and
+`mkisofs`/`genisoimage` for ISO creation.

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -23,7 +23,7 @@ if not os.path.isfile(MKISOFS_EXE):
     MKISOFS_EXE = shutil.which("mkisofs") or "mkisofs"
 
 asm_files = [
-    "bootloader.asm",    # boot sector (must remain first, used for bin)
+    "optrix_kernel/bootloader.asm",    # boot sector (must remain first, used for bin)
     "optrix_kernel/entry.asm",
 ]
 


### PR DESCRIPTION
## Summary
- update README with bootloader details and build tool requirements
- remove old bootloader at repository root
- refine `optrix_kernel/bootloader.asm` to relocate itself and clear low memory

## Testing
- `python3 -m py_compile setup_bootloader.py`
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_684dce93a468832fa08d5a675439e114