### PR TITLE
Improve bootloader with fsboot features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # OptrixOS
 
 This project experiments with building a small Unix-like operating system. The
-boot sector is defined in `optrix_kernel/bootloader.asm` and performs the
-following steps:
+boot sector is defined in `optrix_kernel/bootloader.asm` and now mimics the
+behaviour of the historic `fsboot` loader. When executed it:
 
+- Copies itself away from `0x7c00` so memory can be cleared.
+- Clears a portion of RAM before loading the kernel.
+- Prompts for a kernel path (the input is currently ignored but demonstrates
+  the interface).
 - Loads the kernel from the disk image into memory at `0x1000`.
 - Initializes a simple GDT and switches the CPU to 32-bit protected mode.
 - Jumps to the kernel entry point.


### PR DESCRIPTION
## Summary
- replicate `fsboot` style behaviour in bootloader
- clear memory, prompt for a path and ignore it
- load kernel sectors as before and jump to protected mode
- document changes in README

## Testing
- `python3 setup_bootloader.py`


------
https://chatgpt.com/codex/tasks/task_e_684dd44b9558832f89411f88fefa6508