### PR TITLE
Update build script to fallback to system toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,12 @@ behaviour of the historic `fsboot` loader. When executed it:
 
 Use `python3 setup_bootloader.py` to assemble and link the boot files. The
 script builds a small custom kernel located in `optrix_kernel/` and produces
-`optrix-kernel.bin`. It requires `nasm`, `gcc` with 32-bit support, and `ld`.
+`optrix-kernel.bin`. A cross compiler (`i686-linux-gnu-gcc`/`ld`) is preferred,
+but if it is not installed the script will fall back to the system `gcc` and
+`ld` with `-m32`.
+
+On Ubuntu these tools can be installed with:
+
+```bash
+sudo apt-get install gcc-i686-linux-gnu binutils-i686-linux-gnu genisoimage
+```

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -9,12 +9,21 @@ CC = os.environ.get("CC") or os.path.join(TOOLCHAIN_DIR, "i686-elf-gcc.exe")
 LD = os.environ.get("LD") or os.path.join(TOOLCHAIN_DIR, "i686-elf-ld.exe")
 OBJDUMP = os.environ.get("OBJDUMP") or os.path.join(TOOLCHAIN_DIR, "i686-elf-objdump.exe")
 
+# Try common cross compiler names first
 if not os.path.isfile(CC):
     CC = shutil.which("i686-linux-gnu-gcc") or "i686-linux-gnu-gcc"
 if not os.path.isfile(LD):
     LD = shutil.which("i686-linux-gnu-ld") or "i686-linux-gnu-ld"
 if not os.path.isfile(OBJDUMP):
     OBJDUMP = shutil.which("i686-linux-gnu-objdump") or "i686-linux-gnu-objdump"
+
+# Final fallback to system tools (requires 32-bit support via -m32)
+if not shutil.which(CC):
+    CC = "gcc"
+if not shutil.which(LD):
+    LD = "ld"
+if not shutil.which(OBJDUMP):
+    OBJDUMP = "objdump"
 NASM = "nasm"
 
 CDRTOOLS_DIR = os.environ.get("CDRTOOLS_DIR") or r"C:\\Program Files (x86)\\cdrtools"


### PR DESCRIPTION
## Summary
- add fallback to system GCC/LD when cross compiler isn't found
- document toolchain packages in README

## Testing
- `python3 setup_bootloader.py`


------
https://chatgpt.com/codex/tasks/task_e_684dd7d662a0832f8d03344cfa0988e1