### PR TITLE
Fix boot messages and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ On Ubuntu these tools can be installed with:
 ```bash
 sudo apt-get install gcc-i686-linux-gnu binutils-i686-linux-gnu genisoimage
 ```
+
+Build the bootable image with:
+
+```bash
+python3 setup_bootloader.py
+```
+
+If `mkisofs` is available an ISO named `OptrixOS.iso` is created. Otherwise the
+script outputs `disk.img` which can be run with:
+
+```bash
+qemu-system-x86_64 -hda disk.img
+```

--- a/optrix_kernel/bootloader.asm
+++ b/optrix_kernel/bootloader.asm
@@ -44,6 +44,11 @@ read_char:
 done_read:
     call newline
 
+    ; inform the user we are loading the kernel
+    mov si, load_msg
+    call print_string
+    call newline
+
     ; load kernel from disk (KERNEL_SECTORS sectors) to 0x1000
     mov bx, 0x1000
     mov dh, 0
@@ -54,6 +59,10 @@ done_read:
     mov cl, 2
     int 0x13
     jc disk_error
+
+    mov si, loaded_msg
+    call print_string
+    call newline
 
     ; enter protected mode
     cli
@@ -76,6 +85,8 @@ init_pm:
 
 [bits 16]
 disk_error:
+    mov si, disk_msg
+    call print_string
     hlt
     jmp disk_error
 
@@ -112,6 +123,9 @@ newline:
     ret
 
 prompt_msg db 'Kernel path: ',0
+load_msg   db 'Loading kernel...',0
+loaded_msg db 'Kernel Loaded',0
+disk_msg   db 'Disk read error',0
 PATH_BUF times 64 db 0
 
 BOOT_DRIVE db 0

--- a/optrix_kernel/kmain.c
+++ b/optrix_kernel/kmain.c
@@ -1,5 +1,5 @@
 void kmain(void) {
-    const char *msg = "Optrix kernel loaded";
+    const char *msg = "Kernel Loaded";
     char *video = (char*)0xb8000;
     for (int i = 0; msg[i]; i++) {
         video[i*2] = msg[i];


### PR DESCRIPTION
## Summary
- display messages while loading kernel in bootloader
- print a disk error warning if BIOS disk load fails
- clean up kernel message to a simple `Kernel Loaded`
- document how to run the build script in README

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dda2fdd74832f83d86a017fc3ff83