### PR TITLE
Fix kernel load address in bootloader

### DIFF
--- a/OptrixOS-Kernel/bootloader.asm
+++ b/OptrixOS-Kernel/bootloader.asm
@@ -5,7 +5,12 @@ global boot
 
 BOOT_DRIVE: db 0
 KERNEL_SECTORS equ 16
-KERNEL_LOAD_ADDR equ 0x100000
+; Load the kernel to the physical address matching the linker script
+; (setup_bootloader.py links the kernel with -Ttext 0x1000). Loading
+; above the 1MB boundary would require enabling the A20 line which the
+; bootloader currently does not do, so use 0x1000 which is safely below
+; the real mode limit.
+KERNEL_LOAD_ADDR equ 0x1000
 
 boot:
     mov [BOOT_DRIVE], dl       ; save boot drive


### PR DESCRIPTION
## Summary
- load the kernel below the 1MB boundary
- update bootloader comments

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_684ddfccc85c832f9d27ee1065314c02