### PR TITLE
Fix boot load size and add memory management stubs

### DIFF
--- a/OptrixOS-Kernel/bootloader.asm
+++ b/OptrixOS-Kernel/bootloader.asm
@@ -4,7 +4,11 @@
 global boot
 
 BOOT_DRIVE: db 0
-KERNEL_SECTORS equ 16
+; Number of 512 byte sectors to load for the kernel. The previous value of
+; 16 was insufficient once the kernel grew in size which caused the boot
+; process to hang before the graphical mode was initialised. 32 sectors is
+; plenty of room for the current build and keeps things simple.
+KERNEL_SECTORS equ 32
 KERNEL_LOAD_ADDR equ 0x1000
 
 msg_boot db 'OptrixOS Kernel boot',0

--- a/OptrixOS-Kernel/heap.c
+++ b/OptrixOS-Kernel/heap.c
@@ -1,0 +1,27 @@
+#include "heap.h"
+#include <stdint.h>
+
+/* Very small bump pointer heap located after the kernel. */
+extern uint8_t end; /* Provided by linker */
+static uint8_t* heap_start = &end;
+static uint8_t* heap_end   = (uint8_t*)0x800000; /* 8MB */
+static uint8_t* current    = 0;
+
+void heap_init(void) {
+    current = heap_start;
+}
+
+void* heap_alloc(size_t size) {
+    if (!current)
+        heap_init();
+    if (current + size >= heap_end)
+        return 0;
+    void* ret = current;
+    current += size;
+    return ret;
+}
+
+void heap_free(void* ptr) {
+    /* simple bump allocator cannot free */
+    (void)ptr;
+}

--- a/OptrixOS-Kernel/heap.h
+++ b/OptrixOS-Kernel/heap.h
@@ -1,0 +1,10 @@
+#ifndef HEAP_H
+#define HEAP_H
+
+#include <stddef.h>
+
+void heap_init(void);
+void* heap_alloc(size_t size);
+void heap_free(void* ptr);
+
+#endif /* HEAP_H */

--- a/OptrixOS-Kernel/main.c
+++ b/OptrixOS-Kernel/main.c
@@ -1,6 +1,11 @@
 #include <stdint.h>
 #include "font8x8_basic.h"
 #include "boot_params.h"
+#include "memmap.h"
+#include "pmm.h"
+#include "vmm.h"
+#include "heap.h"
+#include "slab.h"
 
 #define COM1 0x3F8
 
@@ -60,6 +65,22 @@ void main(void) {
     const char* msg = "OS Loaded";
     init_serial();
     log("Kernel start\n");
+
+    memmap_init();
+    pmm_init(memmap_regions(), memmap_region_count());
+    heap_init();
+    slab_init();
+    vmm_init();
+
+    /* simple allocation test */
+    char* test = kmalloc(16);
+    if (test) {
+        for (int i = 0; i < 15; i++) test[i] = 'A' + i;
+        test[15] = '\0';
+        log("Allocated: ");
+        log(test);
+        log("\n");
+    }
 
     // Clear graphics screen
     uint8_t* video = (uint8_t*)0xA0000;

--- a/OptrixOS-Kernel/memmap.c
+++ b/OptrixOS-Kernel/memmap.c
@@ -1,0 +1,29 @@
+#include "memmap.h"
+#include <stdint.h>
+
+static mem_region_t regions[MAX_MEM_REGIONS];
+static size_t region_count = 0;
+
+/* A very small stub that reports a single usable region starting at 1MB.
+   Real boot loaders would query the BIOS using interrupt 0x15 (E820) before
+   entering protected mode and pass the map to the kernel. */
+void memmap_init(void) {
+    regions[0].base = 0x100000;   /* 1MB */
+    regions[0].length = 15 * 1024 * 1024; /* 15MB */
+    regions[0].type = 1;
+    region_count = 1;
+}
+
+size_t memmap_region_count(void) {
+    return region_count;
+}
+
+const mem_region_t* memmap_get(size_t index) {
+    if (index >= region_count)
+        return 0;
+    return &regions[index];
+}
+
+const mem_region_t* memmap_regions(void) {
+    return regions;
+}

--- a/OptrixOS-Kernel/memmap.h
+++ b/OptrixOS-Kernel/memmap.h
@@ -1,0 +1,20 @@
+#ifndef MEMMAP_H
+#define MEMMAP_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define MAX_MEM_REGIONS 16
+
+typedef struct {
+    uint32_t base;
+    uint32_t length;
+    uint32_t type; /* 1=usable */
+} mem_region_t;
+
+void memmap_init(void);
+size_t memmap_region_count(void);
+const mem_region_t* memmap_get(size_t index);
+const mem_region_t* memmap_regions(void);
+
+#endif /* MEMMAP_H */

--- a/OptrixOS-Kernel/pmm.c
+++ b/OptrixOS-Kernel/pmm.c
@@ -1,0 +1,53 @@
+#include "pmm.h"
+#include <stdint.h>
+
+#define MAX_FRAMES 4096
+#define FRAME_SIZE 4096
+
+static uint8_t bitmap[MAX_FRAMES / 8];
+static size_t total_frames = 0;
+
+static inline void set_bit(size_t bit) {
+    bitmap[bit / 8] |= (1 << (bit % 8));
+}
+
+static inline void clear_bit(size_t bit) {
+    bitmap[bit / 8] &= ~(1 << (bit % 8));
+}
+
+static inline int test_bit(size_t bit) {
+    return bitmap[bit / 8] & (1 << (bit % 8));
+}
+
+void pmm_init(const mem_region_t* regions, size_t region_count) {
+    total_frames = 0;
+    for (size_t i = 0; i < MAX_FRAMES / 8; i++)
+        bitmap[i] = 0;
+
+    for (size_t i = 0; i < region_count && total_frames < MAX_FRAMES; i++) {
+        if (regions[i].type != 1)
+            continue;
+        uint32_t start = regions[i].base;
+        uint32_t end = start + regions[i].length;
+        for (uint32_t addr = start; addr + FRAME_SIZE <= end && total_frames < MAX_FRAMES; addr += FRAME_SIZE) {
+            clear_bit(total_frames);
+            total_frames++;
+        }
+    }
+}
+
+void* pmm_alloc(void) {
+    for (size_t i = 0; i < total_frames; i++) {
+        if (!test_bit(i)) {
+            set_bit(i);
+            return (void*)(i * FRAME_SIZE);
+        }
+    }
+    return 0;
+}
+
+void pmm_free(void* frame) {
+    size_t idx = (uintptr_t)frame / FRAME_SIZE;
+    if (idx < total_frames)
+        clear_bit(idx);
+}

--- a/OptrixOS-Kernel/pmm.h
+++ b/OptrixOS-Kernel/pmm.h
@@ -1,0 +1,12 @@
+#ifndef PMM_H
+#define PMM_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include "memmap.h"
+
+void pmm_init(const mem_region_t* regions, size_t region_count);
+void* pmm_alloc(void);
+void pmm_free(void* frame);
+
+#endif /* PMM_H */

--- a/OptrixOS-Kernel/slab.c
+++ b/OptrixOS-Kernel/slab.c
@@ -1,0 +1,14 @@
+#include "slab.h"
+#include "heap.h"
+
+void slab_init(void) {
+    /* Placeholder: our simple allocator uses the kernel heap directly */
+}
+
+void* kmalloc(size_t size) {
+    return heap_alloc(size);
+}
+
+void kfree(void* ptr) {
+    heap_free(ptr);
+}

--- a/OptrixOS-Kernel/slab.h
+++ b/OptrixOS-Kernel/slab.h
@@ -1,0 +1,10 @@
+#ifndef SLAB_H
+#define SLAB_H
+
+#include <stddef.h>
+
+void slab_init(void);
+void* kmalloc(size_t size);
+void kfree(void* ptr);
+
+#endif /* SLAB_H */

--- a/OptrixOS-Kernel/vmm.c
+++ b/OptrixOS-Kernel/vmm.c
@@ -1,0 +1,26 @@
+#include "vmm.h"
+#include "pmm.h"
+#include <stdint.h>
+
+/* Very small identity mapping paging setup. Only enables paging with a single
+   page directory and page table covering the first 4MB. */
+
+#define PAGE_SIZE 4096
+static uint32_t page_directory[1024] __attribute__((aligned(PAGE_SIZE)));
+static uint32_t first_table[1024] __attribute__((aligned(PAGE_SIZE)));
+
+void vmm_init(void) {
+    for (int i = 0; i < 1024; i++) {
+        first_table[i] = (i * PAGE_SIZE) | 3; /* Present, RW */
+    }
+    page_directory[0] = ((uint32_t)first_table) | 3;
+    for (int i = 1; i < 1024; i++)
+        page_directory[i] = 0;
+
+    /* Load page directory */
+    asm volatile("mov %0, %%cr3" :: "r"(page_directory));
+    uint32_t cr0;
+    asm volatile("mov %%cr0, %0" : "=r"(cr0));
+    cr0 |= 0x80000000; /* set PG bit */
+    asm volatile("mov %0, %%cr0" :: "r"(cr0));
+}

--- a/OptrixOS-Kernel/vmm.h
+++ b/OptrixOS-Kernel/vmm.h
@@ -1,0 +1,9 @@
+#ifndef VMM_H
+#define VMM_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+void vmm_init(void);
+
+#endif /* VMM_H */

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -40,6 +40,11 @@ asm_files = [
 c_files = [
     "OptrixOS-Kernel/start.c",
     "OptrixOS-Kernel/main.c",
+    "OptrixOS-Kernel/memmap.c",
+    "OptrixOS-Kernel/pmm.c",
+    "OptrixOS-Kernel/vmm.c",
+    "OptrixOS-Kernel/slab.c",
+    "OptrixOS-Kernel/heap.c",
 ]
 
 tmp_files = []


### PR DESCRIPTION
## Summary
- load more sectors so the kernel is fully read
- stub out memory map, physical memory manager, paging and heap
- compile new sources during bootloader setup

## Testing
- `python3 setup_bootloader.py`
- `qemu-system-x86_64 -hda disk.img -display none -serial stdio -no-reboot -no-shutdown` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de36c7b2c832fbe69fbab448d2b99