### PR TITLE
Improve resources packaging and wallpaper display

### DIFF
--- a/OptrixOS-Kernel/kernel/fabric.c
+++ b/OptrixOS-Kernel/kernel/fabric.c
@@ -68,9 +68,17 @@ static void draw_title_bar(void) {
 
 // --- Load wallpaper from JPEG on ISO ---
 static void load_wallpaper(void) {
-    extern uint8_t* iso9660_read_file(const char* path, size_t* out_size);
+    extern uint8_t* iso9660_load_file(const char* path, size_t* out_size);
+    extern uint8_t _binary_OptrixOS_Kernel_resources_images_wallpaper_jpg_start[];
+    extern uint8_t _binary_OptrixOS_Kernel_resources_images_wallpaper_jpg_end[];
+
     size_t jpg_size = 0;
-    uint8_t* jpg_data = iso9660_read_file("WALLPAPE.JPG", &jpg_size); // Use ISO 9660 file name!
+    uint8_t* jpg_data = iso9660_load_file("WALLPAPE.JPG", &jpg_size); // Use ISO 9660 file name!
+    if (!jpg_data) {
+        jpg_data = _binary_OptrixOS_Kernel_resources_images_wallpaper_jpg_start;
+        jpg_size = _binary_OptrixOS_Kernel_resources_images_wallpaper_jpg_end -
+                   _binary_OptrixOS_Kernel_resources_images_wallpaper_jpg_start;
+    }
 
     int w = 0, h = 0, comp = 0;
     if (jpg_data) {

--- a/OptrixOS-Kernel/kernel/iso9660.c
+++ b/OptrixOS-Kernel/kernel/iso9660.c
@@ -80,3 +80,8 @@ void* iso9660_read_file(const char* filename, size_t* filesize) {
     if (filesize) *filesize = 0;
     return NULL;
 }
+
+// Public alias keeping header name in sync
+void* iso9660_load_file(const char* filename, size_t* filesize) {
+    return iso9660_read_file(filename, filesize);
+}

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -127,9 +127,9 @@ resource_bin_files = [
     # (source_path, output_obj_path)
     ("OptrixOS-Kernel/resources/cursors/oxy-chrome/pointing_hand.cur",
      "_build_obj/_OptrixOS-Kernel_resources_cursors_oxy_chrome_pointing_hand_cur.o"),
-    # Add more resources here as needed:
-    # ("OptrixOS-Kernel/resources/images/wallpaper.jpg",
-    #  "_build_obj/_OptrixOS-Kernel_resources_images_wallpaper_jpg.o"),
+    # Wallpaper used by the desktop UI
+    ("OptrixOS-Kernel/resources/images/wallpaper.jpg",
+     "_build_obj/_OptrixOS-Kernel_resources_images_wallpaper_jpg.o"),
 ]
 
 def objcopy_binary(input_path, output_obj):
@@ -231,6 +231,7 @@ def make_iso_with_tree(tmp_iso_dir, iso_out):
         "-quiet",
         "-o", iso_out,
         "-b", "disk.img",
+        "-R", "-J", "-l",
         tmp_iso_dir
     ]
     run(cmd)


### PR DESCRIPTION
## Summary
- embed wallpaper image as binary resource
- keep long filenames in the generated ISO
- expose `iso9660_load_file` and fall back to built-in wallpaper data

## Testing
- `python3 setup_bootloader.py` *(fails: missing cross compiler)*

------
https://chatgpt.com/codex/tasks/task_e_684f2376e068832f912e41e00c312d96