### PR TITLE
Fix wallpaper path and update build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ script builds a small custom kernel located in `OptrixOS-Kernel/` and produces
 but if it is not installed the script will fall back to the system `gcc` and
 `ld` with `-m32`.
 
+During the build the desktop wallpaper from
+`OptrixOS-Kernel/resources/images/wallpaper.jpg` is automatically copied to the
+ISO root as `WALLPAPE.JPG`. The kernel looks for this 8.3 filename when loading
+the wallpaper at runtime, so ensure it remains in the ISO root if you modify the
+build process.
+
 On Ubuntu these tools can be installed with:
 
 ```bash

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -219,6 +219,13 @@ def copy_tree_to_iso(tmp_iso_dir, proj_root):
         shutil.copy(KERNEL_BIN, os.path.join(tmp_iso_dir, KERNEL_BIN))
     if os.path.exists("disk.img"):
         shutil.copy("disk.img", os.path.join(tmp_iso_dir, "disk.img"))
+    # Explicitly copy wallpaper to ISO root using 8.3 name expected by the
+    # loader. This avoids path lookup issues when the kernel tries to load the
+    # image via iso9660_load_file().
+    wp_src = os.path.join(
+        "OptrixOS-Kernel", "resources", "images", "wallpaper.jpg")
+    if os.path.exists(wp_src):
+        shutil.copy(wp_src, os.path.join(tmp_iso_dir, "WALLPAPE.JPG"))
 
 def make_iso_with_tree(tmp_iso_dir, iso_out):
     print(f"Creating ISO using: {MKISOFS_EXE}")


### PR DESCRIPTION
## Summary
- copy `wallpaper.jpg` into the ISO root as `WALLPAPE.JPG`
- document wallpaper location in README

## Testing
- `python3 -m py_compile setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_684f26c15dcc832fa7a23eab70944d91