### PR TITLE
Fix missing libc functions and headers

### DIFF
--- a/OptrixOS-Kernel/include/stdlib.h
+++ b/OptrixOS-Kernel/include/stdlib.h
@@ -5,7 +5,7 @@
 #define NULL ((void*)0)
 #endif
 
-typedef unsigned long size_t;
+#include <stddef.h>
 
 void* malloc(size_t size);  // You can just return NULL or use your allocator
 void  free(void* ptr);      // No-op for now

--- a/OptrixOS-Kernel/include/string.h
+++ b/OptrixOS-Kernel/include/string.h
@@ -39,4 +39,13 @@ static inline char *strcpy(char *dst, const char *src) {
     return ret;
 }
 
+// Find first occurrence of character c in s, or return NULL
+static inline char *strchr(const char *s, int c) {
+    while (*s) {
+        if (*s == (char)c) return (char*)s;
+        ++s;
+    }
+    return NULL;
+}
+
 #endif // _STRING_H_

--- a/include/limits.h
+++ b/include/limits.h
@@ -1,0 +1,22 @@
+#ifndef _LIMITS_H_
+#define _LIMITS_H_
+
+#define CHAR_BIT 8
+
+#define SCHAR_MIN (-128)
+#define SCHAR_MAX 127
+#define UCHAR_MAX 255
+
+#define SHRT_MIN (-32768)
+#define SHRT_MAX 32767
+#define USHRT_MAX 65535
+
+#define INT_MIN (-2147483648)
+#define INT_MAX 2147483647
+#define UINT_MAX 0xffffffffU
+
+#define LONG_MIN (-2147483648L)
+#define LONG_MAX 2147483647L
+#define ULONG_MAX 0xffffffffUL
+
+#endif // _LIMITS_H_


### PR DESCRIPTION
## Summary
- add `strchr` implementation to custom string.h
- fix stdlib.h type conflict
- provide minimal limits.h for freestanding builds

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs.exe not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2da5c3f8832fb373519b09d2e759