### PR TITLE
Fix wallpaper loading and remove system limits dependency

### DIFF
--- a/OptrixOS-Kernel/include/assert.h
+++ b/OptrixOS-Kernel/include/assert.h
@@ -1,0 +1,15 @@
+#ifndef ASSERT_H
+#define ASSERT_H
+
+#ifdef NDEBUG
+#define assert(expr) ((void)0)
+#else
+static inline void __assert_fail(const char *expr, const char *file, int line) {
+    (void)file; (void)line; (void)expr;
+    // In a real kernel we might log this. Here we just halt.
+    for(;;) { __asm__ __volatile__("hlt"); }
+}
+#define assert(expr) ((expr) ? (void)0 : __assert_fail(#expr, __FILE__, __LINE__))
+#endif
+
+#endif // ASSERT_H

--- a/OptrixOS-Kernel/include/limits.h
+++ b/OptrixOS-Kernel/include/limits.h
@@ -1,0 +1,18 @@
+#ifndef LIMITS_H
+#define LIMITS_H
+
+#define CHAR_BIT    8
+#define SCHAR_MAX   127
+#define SCHAR_MIN   (-128)
+#define UCHAR_MAX   255
+#define SHRT_MAX    32767
+#define SHRT_MIN    (-32768)
+#define USHRT_MAX   65535
+#define INT_MAX     2147483647
+#define INT_MIN     (-2147483647-1)
+#define UINT_MAX    4294967295U
+#define LONG_MAX    2147483647L
+#define LONG_MIN    (-2147483647L-1)
+#define ULONG_MAX   4294967295UL
+
+#endif // LIMITS_H

--- a/OptrixOS-Kernel/include/stb_image.h
+++ b/OptrixOS-Kernel/include/stb_image.h
@@ -588,7 +588,25 @@ STBIDEF int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const ch
 #include <stddef.h> // ptrdiff_t on osx
 #include <stdlib.h>
 #include <string.h>
+#ifndef STBI_NO_LIMITS
 #include <limits.h>
+#else
+#ifndef INT_MAX
+#define INT_MAX 2147483647
+#endif
+#ifndef INT_MIN
+#define INT_MIN (-2147483647-1)
+#endif
+#ifndef UINT_MAX
+#define UINT_MAX 4294967295U
+#endif
+#ifndef SHRT_MAX
+#define SHRT_MAX 32767
+#endif
+#ifndef SHRT_MIN
+#define SHRT_MIN (-32768)
+#endif
+#endif
 
 #if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR)
 #include <math.h>  // ldexp, pow

--- a/OptrixOS-Kernel/kernel/fabric.c
+++ b/OptrixOS-Kernel/kernel/fabric.c
@@ -14,6 +14,7 @@ void* kernel_realloc(void* ptr, size_t size) { return NULL; }
 #define STBI_REALLOC(p,sz)   kernel_realloc(p,sz)
 #define STBI_FREE(p)         kernel_free(p)
 #define STBI_NO_STDIO
+#define STBI_NO_LIMITS
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb_image.h"
 
@@ -68,18 +69,13 @@ static void draw_title_bar(void) {
 
 // --- Load wallpaper from JPEG on ISO ---
 static void load_wallpaper(void) {
-    extern uint8_t* iso9660_load_file(const char* path, size_t* out_size);
     extern uint8_t _binary_OptrixOS_Kernel_resources_images_wallpaper_jpg_start[];
     extern uint8_t _binary_OptrixOS_Kernel_resources_images_wallpaper_jpg_end[];
 
-    size_t jpg_size = 0;
-    uint8_t* jpg_data = iso9660_load_file(
-        "OptrixOS-Kernel/resources/images/WALLPAPE.JPG", &jpg_size);
-    if (!jpg_data) {
-        jpg_data = _binary_OptrixOS_Kernel_resources_images_wallpaper_jpg_start;
-        jpg_size = _binary_OptrixOS_Kernel_resources_images_wallpaper_jpg_end -
-                   _binary_OptrixOS_Kernel_resources_images_wallpaper_jpg_start;
-    }
+    // Always use the embedded wallpaper to avoid ISO lookup issues
+    size_t jpg_size = _binary_OptrixOS_Kernel_resources_images_wallpaper_jpg_end -
+                      _binary_OptrixOS_Kernel_resources_images_wallpaper_jpg_start;
+    uint8_t* jpg_data = _binary_OptrixOS_Kernel_resources_images_wallpaper_jpg_start;
 
     int w = 0, h = 0, comp = 0;
     if (jpg_data) {


### PR DESCRIPTION
## Summary
- provide functional kernel `assert.h`
- add a freestanding `limits.h` and avoid system headers in `stb_image.h`
- always load the embedded wallpaper image
- enable `STBI_NO_LIMITS` when including stb_image

## Testing
- `python3 setup_bootloader.py` *(fails: `mkisofs.exe` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f309b87a8832f8af9d4203996a594