### PR TITLE
Fix fabric framebuffer init

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -32,6 +32,12 @@ boot:
     mov bx, 0x4118       ; 1024x768x32bpp linear framebuffer
     int 0x10
 
+    ; Query mode information to obtain framebuffer physical address
+    mov ax, 0x4F01
+    mov cx, 0x118
+    mov di, 0x9000       ; store VBE mode info structure at 0x9000
+    int 0x10
+
     ; Load kernel
     mov bx, KERNEL_LOAD_ADDR
     mov dh, 0

--- a/OptrixOS-Kernel/asm/kernel_entry.asm
+++ b/OptrixOS-Kernel/asm/kernel_entry.asm
@@ -2,7 +2,11 @@
 section .text
 global kernel_entry
 extern kernel_main
+extern framebuffer
 kernel_entry:
+    ; Retrieve VBE framebuffer physical address stored by bootloader
+    mov eax, [0x9000 + 40]
+    mov [framebuffer], eax
     mov esp, 0x90000
     call kernel_main
 .halt:

--- a/OptrixOS-Kernel/include/video.h
+++ b/OptrixOS-Kernel/include/video.h
@@ -1,0 +1,9 @@
+#ifndef VIDEO_H
+#define VIDEO_H
+#include <stdint.h>
+
+extern uint32_t* framebuffer;
+extern uint32_t framebuffer_width;
+extern uint32_t framebuffer_height;
+
+#endif // VIDEO_H

--- a/OptrixOS-Kernel/kernel/fabric.c
+++ b/OptrixOS-Kernel/kernel/fabric.c
@@ -2,11 +2,11 @@
 #include <stddef.h>
 #include "cursor.h"
 #include "wallpaper.h"
+#include "video.h"
+#include "fabric_defs.h"
 
 // --- UI CONSTANTS ---
-#define WIDTH   1024
-#define HEIGHT  768
-#define FB_ADDR ((uint32_t*)0xE0000000) // Set to your real framebuffer address
+#define FB_ADDR framebuffer
 
 // Mouse globals -- ONLY declare here, define in mouse.c!
 extern volatile int mouse_x, mouse_y;

--- a/OptrixOS-Kernel/kernel/video.c
+++ b/OptrixOS-Kernel/kernel/video.c
@@ -1,0 +1,6 @@
+#include "video.h"
+#include "fabric_defs.h"
+
+uint32_t* framebuffer = (uint32_t*)0;
+uint32_t framebuffer_width = WIDTH;
+uint32_t framebuffer_height = HEIGHT;


### PR DESCRIPTION
## Summary
- query VBE mode info in bootloader to get true framebuffer address
- pass framebuffer address to kernel
- provide global video variables
- update fabric to use runtime framebuffer

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_684f37870a5c832fad77ba090a698263