### PR TITLE
Fix kernel load using BIOS LBA and set segment registers

### DIFF
--- a/OptrixOS-Kernel/asm/kernel_entry.asm
+++ b/OptrixOS-Kernel/asm/kernel_entry.asm
@@ -4,6 +4,12 @@ global kernel_entry
 extern kernel_main
 kernel_entry:
     ; Simple 32-bit entry
+    mov ax, 0x10
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
     mov esp, 0x90000
     call kernel_main
 .halt:


### PR DESCRIPTION
## Summary
- switch bootloader to BIOS LBA reads so loading works from hard disk/ISO
- set data segments before printing and in the kernel entry routine

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5c137218832f8a40441dcf8c5b4e