### PR TITLE
Enable protected mode bootloader

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -21,8 +21,42 @@ start:
     mov cx, 0x0002    ; cylinder/head/sector = sector 2
     int 0x13
 
-    ; jump to kernel
-    jmp 0x0000:0x1000
+    ; setup basic GDT for protected mode
+    lgdt [gdt_desc]
+
+    ; enable protected mode
+    mov eax, cr0
+    or eax, 1
+    mov cr0, eax
+    jmp 0x08:protected_mode
+
+; 32-bit protected mode code
+[BITS 32]
+protected_mode:
+    mov ax, 0x10
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
+    mov esp, 0x90000
+
+    call dword 0x1000
+.halt:
+    hlt
+    jmp .halt
+
+; GDT setup
+[BITS 16]
+gdt_start:
+    dq 0x0000000000000000
+    dq 0x00cf9a000000ffff ; code segment
+    dq 0x00cf92000000ffff ; data segment
+gdt_end:
+
+gdt_desc:
+    dw gdt_end - gdt_start - 1
+    dd gdt_start
 
 BOOT_DRIVE: db 0
 


### PR DESCRIPTION
## Summary
- set up a small GDT and switch to 32-bit protected mode
- call the kernel entry from protected mode so the VGA border draws correctly

## Testing
- `make clean`
- `make all`

------
https://chatgpt.com/codex/tasks/task_e_684f6360ef88832f81fb86822cef7e75