### PR TITLE
Add basic terminal with keyboard input

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -5,11 +5,14 @@ all: disk.img
 bootloader.bin: asm/bootloader.asm
 	@nasm -f bin $< -o $@
 
-kernel.bin: asm/kernel.asm src/graphics.o src/screen.o
+kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/terminal.o
 	@nasm -f elf32 asm/kernel.asm -o kernel_asm.o
+	@nasm -f elf32 asm/ports.asm -o ports.o
 	@gcc $(CFLAGS) -c src/graphics.c -o src/graphics.o
 	@gcc $(CFLAGS) -c src/screen.c -o src/screen.o
-	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o src/graphics.o src/screen.o 		--oformat binary -o $@
+	@gcc $(CFLAGS) -c src/keyboard.c -o src/keyboard.o
+	@gcc $(CFLAGS) -c src/terminal.c -o src/terminal.o
+	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o src/graphics.o src/screen.o src/keyboard.o src/terminal.o --oformat binary -o $@
 
 disk.img: bootloader.bin kernel.bin
 	@cat bootloader.bin kernel.bin > $@

--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -13,8 +13,8 @@ start:
     mov ss, ax
     mov sp, 0x7C00
 
-    ; Set video mode 13h (320x200x256)
-    mov ax, 0x0013
+    ; Set video mode 03h (80x25 text)
+    mov ax, 0x0003
     int 0x10
 
     ; load kernel (assumes kernel starts at second sector)

--- a/OptrixOS-Kernel/asm/kernel.asm
+++ b/OptrixOS-Kernel/asm/kernel.asm
@@ -1,10 +1,14 @@
 BITS 32
 
 extern screen_init
+extern terminal_init
+extern terminal_run
 
 global start
 start:
     call screen_init
+    call terminal_init
+    call terminal_run
 .halt:
     hlt
     jmp .halt

--- a/OptrixOS-Kernel/asm/ports.asm
+++ b/OptrixOS-Kernel/asm/ports.asm
@@ -1,0 +1,16 @@
+[BITS 32]
+
+GLOBAL inb
+GLOBAL outb
+
+inb:
+    mov edx, [esp+4]
+    in al, dx
+    movzx eax, al
+    ret
+
+outb:
+    mov edx, [esp+4]
+    mov al, [esp+8]
+    out dx, al
+    ret

--- a/OptrixOS-Kernel/include/keyboard.h
+++ b/OptrixOS-Kernel/include/keyboard.h
@@ -1,0 +1,4 @@
+#ifndef KEYBOARD_H
+#define KEYBOARD_H
+char keyboard_getchar(void);
+#endif

--- a/OptrixOS-Kernel/include/ports.h
+++ b/OptrixOS-Kernel/include/ports.h
@@ -1,0 +1,6 @@
+#ifndef PORTS_H
+#define PORTS_H
+#include <stdint.h>
+uint8_t inb(uint16_t port);
+void outb(uint16_t port, uint8_t data);
+#endif

--- a/OptrixOS-Kernel/include/terminal.h
+++ b/OptrixOS-Kernel/include/terminal.h
@@ -1,0 +1,5 @@
+#ifndef TERMINAL_H
+#define TERMINAL_H
+void terminal_init(void);
+void terminal_run(void);
+#endif

--- a/OptrixOS-Kernel/src/keyboard.c
+++ b/OptrixOS-Kernel/src/keyboard.c
@@ -1,0 +1,22 @@
+#include "keyboard.h"
+#include "ports.h"
+#include <stdint.h>
+
+static const char sc_ascii[] = {
+    0,  27, '1','2','3','4','5','6','7','8','9','0','-','=',\
+    '\b',\
+    '\t','q','w','e','r','t','y','u','i','o','p','[',']','\n',\
+    0,'a','s','d','f','g','h','j','k','l',';','\'', '`',0,\
+    '\\','z','x','c','v','b','n','m',',','.','/',0,'*',0,' ',0,
+};
+
+char keyboard_getchar(void) {
+    uint8_t sc = 0;
+    while(!(inb(0x64) & 1)) {}
+    sc = inb(0x60);
+    if(sc & 0x80)
+        return 0;
+    if(sc >= sizeof(sc_ascii))
+        return 0;
+    return sc_ascii[sc];
+}

--- a/OptrixOS-Kernel/src/screen.c
+++ b/OptrixOS-Kernel/src/screen.c
@@ -1,10 +1,18 @@
 #include "screen.h"
-#include "graphics.h"
+#include <stdint.h>
+
+#define WIDTH 80
+#define HEIGHT 25
+
+static volatile uint16_t* const VIDEO = (uint16_t*)0xB8000;
 
 void screen_init(void) {
-    draw_rect(0, 0, 320, 200, 0); // clear to black
-    draw_rect(0, 0, 320, 1, 15);   // top
-    draw_rect(0, 199, 320, 1, 15); // bottom
-    draw_rect(0, 0, 1, 200, 15);   // left
-    draw_rect(319, 0, 1, 200, 15); // right
+    for(int y = 0; y < HEIGHT; y++) {
+        for(int x = 0; x < WIDTH; x++) {
+            uint8_t color = 0x1;              /* blue background */
+            if(y == 0 || y == HEIGHT-1 || x == 0 || x == WIDTH-1)
+                color = 0x0F;                 /* white border */
+            VIDEO[y*WIDTH + x] = ((uint16_t)color << 8) | ' ';
+        }
+    }
 }

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -1,0 +1,130 @@
+#include "terminal.h"
+#include "keyboard.h"
+#include <stdint.h>
+#include <stddef.h>
+
+static int streq(const char* a, const char* b) {
+    while(*a && *b) {
+        if(*a != *b) return 0;
+        a++; b++;
+    }
+    return *a == *b;
+}
+
+static int strprefix(const char* str, const char* pre) {
+    while(*pre) {
+        if(*str != *pre) return 0;
+        str++; pre++;
+    }
+    return 1;
+}
+
+#define WIDTH 80
+#define HEIGHT 25
+#define BORDER_COLOR 0x0F
+#define TEXT_COLOR 0x0E
+
+static volatile uint16_t* const VIDEO = (uint16_t*)0xB8000;
+static int row = 1;
+static int col = 1;
+
+static void put_entry_at(char c, uint8_t color, int x, int y) {
+    VIDEO[y * WIDTH + x] = ((uint16_t)color << 8) | c;
+}
+
+static void scroll(void) {
+    for(int y=2; y<HEIGHT-1; y++) {
+        for(int x=1; x<WIDTH-1; x++) {
+            VIDEO[(y-1)*WIDTH + x] = VIDEO[y*WIDTH + x];
+        }
+    }
+    for(int x=1; x<WIDTH-1; x++)
+        VIDEO[(HEIGHT-2)*WIDTH + x] = ((uint16_t)0x01 << 8) | ' ';
+}
+
+static void putchar(char c) {
+    if(c=='\n') {
+        row++;
+        col=1;
+    } else {
+        put_entry_at(c, TEXT_COLOR, col, row);
+        col++;
+        if(col >= WIDTH-1) {
+            col=1;
+            row++;
+        }
+    }
+    if(row >= HEIGHT-1) {
+        scroll();
+        row = HEIGHT-2;
+    }
+}
+
+void terminal_init(void) {
+    row = 1;
+    col = 1;
+}
+
+static void print(const char* str) {
+    for(size_t i=0; str[i]; i++)
+        putchar(str[i]);
+}
+
+static void read_line(char* buf, size_t max) {
+    size_t idx=0;
+    while(idx < max-1) {
+        char c = keyboard_getchar();
+        if(!c) continue;
+        if(c=='\n') {
+            putchar('\n');
+            break;
+        }
+        if(c=='\b') {
+            if(idx>0) { idx--; col--; putchar(' '); col--; }
+            continue;
+        }
+        putchar(c);
+        buf[idx++] = c;
+    }
+    buf[idx]='\0';
+}
+
+static void cmd_help(void) {
+    print("Available commands:\n");
+    print("help - show this help\n");
+    print("clear - clear the screen\n");
+    print("echo  - echo text\n");
+}
+
+static void cmd_clear(void) {
+    for(int y=1; y<HEIGHT-1; y++)
+        for(int x=1; x<WIDTH-1; x++)
+            VIDEO[y*WIDTH + x] = ((uint16_t)0x01 << 8) | ' ';
+    row=1; col=1;
+}
+
+static void cmd_echo(const char* args) {
+    print(args);
+    putchar('\n');
+}
+
+static void execute(const char* line) {
+    if(streq(line, "help")) {
+        cmd_help();
+    } else if(streq(line, "clear")) {
+        cmd_clear();
+    } else if(strprefix(line, "echo ")) {
+        cmd_echo(line+5);
+    } else if(line[0]) {
+        print("Unknown command\n");
+    }
+}
+
+void terminal_run(void) {
+    char buf[128];
+    while(1) {
+        print("> ");
+        read_line(buf, sizeof(buf));
+        execute(buf);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -42,3 +42,14 @@ script outputs `disk.img` which can be run with:
 ```bash
 qemu-system-x86_64 -hda disk.img
 ```
+
+## Built-in terminal
+
+After boot a simple text terminal is available. The border is drawn in white and
+the background is blue. The terminal automatically scrolls as it fills. The
+following commands are implemented:
+
+* `help`  - display available commands
+* `clear` - clear the screen
+* `echo`  - echo arbitrary text
+


### PR DESCRIPTION
## Summary
- switch bootloader to VGA text mode
- draw blue screen with a white border
- implement a simple terminal and keyboard driver
- expose ports helpers in assembly
- document new terminal commands

## Testing
- `python3 setup_bootloader.py`


------
https://chatgpt.com/codex/tasks/task_e_684f773a3ae0832f9af4cbb451720d35