### PR TITLE
Add software cursor and terminal improvements

### DIFF
--- a/OptrixOS-Kernel/src/keyboard.c
+++ b/OptrixOS-Kernel/src/keyboard.c
@@ -11,9 +11,9 @@ static const char sc_ascii[] = {
 };
 
 char keyboard_getchar(void) {
-    uint8_t sc = 0;
-    while(!(inb(0x64) & 1)) {}
-    sc = inb(0x60);
+    if(!(inb(0x64) & 1))
+        return 0;
+    uint8_t sc = inb(0x60);
     if(sc & 0x80)
         return 0;
     if(sc >= sizeof(sc_ascii))

--- a/OptrixOS-Kernel/src/screen.c
+++ b/OptrixOS-Kernel/src/screen.c
@@ -1,4 +1,5 @@
 #include "screen.h"
+#include "ports.h"
 #include <stdint.h>
 
 #define WIDTH 80
@@ -10,9 +11,26 @@ void screen_init(void) {
     for(int y = 0; y < HEIGHT; y++) {
         for(int x = 0; x < WIDTH; x++) {
             uint8_t color = 0x1;              /* blue background */
-            if(y == 0 || y == HEIGHT-1 || x == 0 || x == WIDTH-1)
-                color = 0x0F;                 /* white border */
-            VIDEO[y*WIDTH + x] = ((uint16_t)color << 8) | ' ';
+            char ch = ' ';
+            if(y == 0 || y == HEIGHT-1) {
+                color = 0x0F;                 /* border */
+                ch = '=';
+            } else if(x == 0 || x == WIDTH-1) {
+                color = 0x0F;                 /* border */
+                ch = '|';
+            }
+            VIDEO[y*WIDTH + x] = ((uint16_t)color << 8) | ch;
         }
     }
+
+    const char *title = "OptrixOS Terminal";
+    int len = 0;
+    while(title[len]) len++;
+    int start = (WIDTH - len) / 2;
+    for(int i = 0; title[i]; i++)
+        VIDEO[start + i] = ((uint16_t)0x0F << 8) | title[i];
+
+    /* hide hardware cursor */
+    outb(0x3D4, 0x0A);
+    outb(0x3D5, 0x20);
 }

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -1,5 +1,6 @@
 #include "terminal.h"
 #include "keyboard.h"
+#include "screen.h"
 #include <stdint.h>
 #include <stddef.h>
 
@@ -23,10 +24,19 @@ static int strprefix(const char* str, const char* pre) {
 #define HEIGHT 25
 #define BORDER_COLOR 0x0F
 #define TEXT_COLOR 0x0E
+#define CURSOR_COLOR 0x1E
+#define CURSOR_CHAR '_'
 
 static volatile uint16_t* const VIDEO = (uint16_t*)0xB8000;
 static int row = 1;
 static int col = 1;
+static int cursor_on = 0;
+
+static void draw_cursor(int visible) {
+    char ch = visible ? CURSOR_CHAR : ' ';
+    uint8_t color = visible ? CURSOR_COLOR : 0x01;
+    VIDEO[row * WIDTH + col] = ((uint16_t)color << 8) | ch;
+}
 
 static void put_entry_at(char c, uint8_t color, int x, int y) {
     VIDEO[y * WIDTH + x] = ((uint16_t)color << 8) | c;
@@ -43,6 +53,7 @@ static void scroll(void) {
 }
 
 static void putchar(char c) {
+    draw_cursor(0);
     if(c=='\n') {
         row++;
         col=1;
@@ -58,11 +69,13 @@ static void putchar(char c) {
         scroll();
         row = HEIGHT-2;
     }
+    draw_cursor(1);
 }
 
 void terminal_init(void) {
     row = 1;
     col = 1;
+    draw_cursor(1);
 }
 
 static void print(const char* str) {
@@ -70,23 +83,43 @@ static void print(const char* str) {
         putchar(str[i]);
 }
 
+static void pause(void) {
+    for(volatile int i=0; i<10000; i++);
+}
+
 static void read_line(char* buf, size_t max) {
-    size_t idx=0;
+    size_t idx = 0;
+    int blink = 0;
+    cursor_on = 1;
+    draw_cursor(1);
     while(idx < max-1) {
         char c = keyboard_getchar();
-        if(!c) continue;
-        if(c=='\n') {
+        if(!c) {
+            blink++;
+            if(blink > 5000) {
+                blink = 0;
+                cursor_on = !cursor_on;
+                draw_cursor(cursor_on);
+            }
+            pause();
+            continue;
+        }
+        if(cursor_on) { draw_cursor(0); cursor_on = 0; }
+        if(c == '\n') {
             putchar('\n');
+            draw_cursor(1);
             break;
         }
-        if(c=='\b') {
-            if(idx>0) { idx--; col--; putchar(' '); col--; }
+        if(c == '\b') {
+            if(idx > 0) { idx--; col--; putchar(' '); col--; }
+            draw_cursor(1);
             continue;
         }
         putchar(c);
         buf[idx++] = c;
     }
-    buf[idx]='\0';
+    draw_cursor(0);
+    buf[idx] = '\0';
 }
 
 static void cmd_help(void) {
@@ -94,6 +127,7 @@ static void cmd_help(void) {
     print("help - show this help\n");
     print("clear - clear the screen\n");
     print("echo  - echo text\n");
+    print("about - about this OS\n");
 }
 
 static void cmd_clear(void) {
@@ -108,6 +142,10 @@ static void cmd_echo(const char* args) {
     putchar('\n');
 }
 
+static void cmd_about(void) {
+    print("OptrixOS experimental kernel\n");
+}
+
 static void execute(const char* line) {
     if(streq(line, "help")) {
         cmd_help();
@@ -115,6 +153,8 @@ static void execute(const char* line) {
         cmd_clear();
     } else if(strprefix(line, "echo ")) {
         cmd_echo(line+5);
+    } else if(streq(line, "about")) {
+        cmd_about();
     } else if(line[0]) {
         print("Unknown command\n");
     }

--- a/README.md
+++ b/README.md
@@ -45,11 +45,14 @@ qemu-system-x86_64 -hda disk.img
 
 ## Built-in terminal
 
-After boot a simple text terminal is available. The border is drawn in white and
-the background is blue. The terminal automatically scrolls as it fills. The
-following commands are implemented:
+After boot a simple text terminal is available. The screen now shows a title
+bar with a decorative border and a blinking yellow software cursor. The
+hardware text mode cursor is disabled so only the custom cursor is visible. The
+terminal automatically scrolls as it fills. The following commands are
+implemented:
 
 * `help`  - display available commands
 * `clear` - clear the screen
 * `echo`  - echo arbitrary text
+* `about` - display information about OptrixOS
 


### PR DESCRIPTION
## Summary
- render fancy border layout and title bar when initializing the screen
- disable the hardware text cursor and show a blinking yellow software cursor
- poll keyboard input so the cursor can blink
- add an `about` command and document it in the README

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_684f794f3678832f88770526f9b96951