### PR TITLE
Customize terminal border and colors

### DIFF
--- a/OptrixOS-Kernel/src/screen.c
+++ b/OptrixOS-Kernel/src/screen.c
@@ -8,18 +8,24 @@
 static volatile uint16_t* const VIDEO = (uint16_t*)0xB8000;
 
 void screen_init(void) {
+    const char tl = '\xC9';
+    const char tr = '\xBB';
+    const char bl = '\xC8';
+    const char br = '\xBC';
+    const char hline = '\xCD';
+    const char vline = '\xBA';
+
     for(int y = 0; y < HEIGHT; y++) {
         for(int x = 0; x < WIDTH; x++) {
-            uint8_t color = 0x1;              /* blue background */
+            uint8_t color = 0x00;             /* black background */
             char ch = ' ';
-            if(y == 0 || y == HEIGHT-1) {
-                color = 0x0F;                 /* border */
-                ch = '=';
-            } else if(x == 0 || x == WIDTH-1) {
-                color = 0x0F;                 /* border */
-                ch = '|';
-            }
-            VIDEO[y*WIDTH + x] = ((uint16_t)color << 8) | ch;
+            if(y == 0 && x == 0) { ch = tl; color = 0x0F; }
+            else if(y == 0 && x == WIDTH-1) { ch = tr; color = 0x0F; }
+            else if(y == HEIGHT-1 && x == 0) { ch = bl; color = 0x0F; }
+            else if(y == HEIGHT-1 && x == WIDTH-1) { ch = br; color = 0x0F; }
+            else if(y == 0 || y == HEIGHT-1) { ch = hline; color = 0x0F; }
+            else if(x == 0 || x == WIDTH-1) { ch = vline; color = 0x0F; }
+            VIDEO[y*WIDTH + x] = ((uint16_t)color << 8) | (unsigned char)ch;
         }
     }
 

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -24,7 +24,7 @@ static int strprefix(const char* str, const char* pre) {
 #define HEIGHT 25
 #define BORDER_COLOR 0x0F
 #define TEXT_COLOR 0x0E
-#define CURSOR_COLOR 0x1E
+#define CURSOR_COLOR 0x0E
 #define CURSOR_CHAR '_'
 
 static volatile uint16_t* const VIDEO = (uint16_t*)0xB8000;
@@ -34,7 +34,7 @@ static int cursor_on = 0;
 
 static void draw_cursor(int visible) {
     char ch = visible ? CURSOR_CHAR : ' ';
-    uint8_t color = visible ? CURSOR_COLOR : 0x01;
+    uint8_t color = visible ? CURSOR_COLOR : 0x00;
     VIDEO[row * WIDTH + col] = ((uint16_t)color << 8) | ch;
 }
 
@@ -49,7 +49,7 @@ static void scroll(void) {
         }
     }
     for(int x=1; x<WIDTH-1; x++)
-        VIDEO[(HEIGHT-2)*WIDTH + x] = ((uint16_t)0x01 << 8) | ' ';
+        VIDEO[(HEIGHT-2)*WIDTH + x] = ((uint16_t)0x00 << 8) | ' ';
 }
 
 static void putchar(char c) {
@@ -133,7 +133,7 @@ static void cmd_help(void) {
 static void cmd_clear(void) {
     for(int y=1; y<HEIGHT-1; y++)
         for(int x=1; x<WIDTH-1; x++)
-            VIDEO[y*WIDTH + x] = ((uint16_t)0x01 << 8) | ' ';
+            VIDEO[y*WIDTH + x] = ((uint16_t)0x00 << 8) | ' ';
     row=1; col=1;
 }
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ qemu-system-x86_64 -hda disk.img
 ## Built-in terminal
 
 After boot a simple text terminal is available. The screen now shows a title
-bar with a decorative border and a blinking yellow software cursor. The
-hardware text mode cursor is disabled so only the custom cursor is visible. The
+bar with a box-drawing border rendered using VGA graphics characters. The
+background is black with yellow text and the blinking software cursor matches
+the text colour. The hardware text mode cursor is disabled so only the custom
+cursor is visible. The
 terminal automatically scrolls as it fills. The following commands are
 implemented:
 


### PR DESCRIPTION
## Summary
- use VGA box characters for border
- keep background black and draw text/cursor in yellow
- hide hardware cursor

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_684f7ab9ed04832f9552ddac17e8fc39