### PR TITLE
Fix terminal cursor after backspace

### DIFF
--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -111,8 +111,13 @@ static void read_line(char* buf, size_t max) {
             break;
         }
         if(c == '\b') {
-            if(idx > 0) { idx--; col--; putchar(' '); col--; }
-            draw_cursor(1);
+            if(idx > 0) {
+                draw_cursor(0);         /* remove cursor from current position */
+                col--;                  /* move back one column */
+                idx--;                  /* update buffer index */
+                put_entry_at(' ', 0x00, col, row); /* clear character */
+                draw_cursor(1);         /* redraw cursor at new position */
+            }
             continue;
         }
         putchar(c);


### PR DESCRIPTION
## Summary
- improve terminal backspace handling so the software cursor is cleared and redrawn properly

## Testing
- `make -C OptrixOS-Kernel clean all`
- `python3 setup_bootloader.py` *(fails: `mkisofs.exe not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684f7cde6104832faae61a218bcc233a