### PR TITLE
Fix terminal scaling and update docs

### DIFF
--- a/OptrixOS-Kernel/src/screen.c
+++ b/OptrixOS-Kernel/src/screen.c
@@ -2,8 +2,8 @@
 #include "ports.h"
 #include <stdint.h>
 
-#define WIDTH 100
-#define HEIGHT 30
+#define WIDTH 80
+#define HEIGHT 25
 
 static volatile uint16_t* const VIDEO = (uint16_t*)0xB8000;
 

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -20,8 +20,8 @@ static int strprefix(const char* str, const char* pre) {
     return 1;
 }
 
-#define WIDTH 100
-#define HEIGHT 30
+#define WIDTH 80
+#define HEIGHT 25
 #define BORDER_COLOR 0x0F
 #define DEFAULT_TEXT_COLOR 0x0E
 #define CURSOR_COLOR 0x0E

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ qemu-system-x86_64 -hda disk.img
 
 ## Built-in terminal
 
-After boot a simple text terminal is available. The screen now displays at a
-larger resolution of 100x30 characters and shows a title bar with a
+After boot a simple text terminal is available. The screen displays in the
+standard 80x25 text mode and shows a title bar with a
 box-drawing border rendered using VGA graphics characters. The background is
 black with yellow text and the blinking software cursor matches the text
 colour. The hardware text mode cursor is disabled so only the custom cursor is


### PR DESCRIPTION
## Summary
- use standard 80x25 text mode in screen and terminal code
- update README to match actual resolution

## Testing
- `make -C OptrixOS-Kernel clean all`

------
https://chatgpt.com/codex/tasks/task_e_684f8177ad10832f87bf324d2ee3b98c