### PR TITLE
Improve terminal layout

### DIFF
--- a/OptrixOS-Kernel/include/screen.h
+++ b/OptrixOS-Kernel/include/screen.h
@@ -3,8 +3,14 @@
 
 #include <stdint.h>
 
-#define SCREEN_COLS 37
-#define SCREEN_ROWS 27
+#define SCREEN_WIDTH 800
+#define SCREEN_HEIGHT 600
+#define CHAR_WIDTH 12
+#define CHAR_HEIGHT 16
+#define OFFSET_X 8
+#define OFFSET_Y 8
+#define SCREEN_COLS ((SCREEN_WIDTH - 2*OFFSET_X) / CHAR_WIDTH)
+#define SCREEN_ROWS ((SCREEN_HEIGHT - 2*OFFSET_Y) / CHAR_HEIGHT)
 
 void screen_init(void);
 void screen_clear(void);

--- a/OptrixOS-Kernel/src/screen.c
+++ b/OptrixOS-Kernel/src/screen.c
@@ -3,12 +3,6 @@
 #include "font/font8x8_basic.h"
 #include <stdint.h>
 
-#define SCREEN_WIDTH 800
-#define SCREEN_HEIGHT 600
-#define CHAR_WIDTH 21
-#define CHAR_HEIGHT 21
-#define OFFSET_X 8
-#define OFFSET_Y 8
 
 void screen_clear(void) {
     draw_rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, 0x00);
@@ -17,10 +11,14 @@ void screen_clear(void) {
 static void draw_border(void) {
     for(int x=0; x<SCREEN_WIDTH; x++) {
         put_pixel(x, 0, 0x0F);
+        put_pixel(x, 1, 0x09);
+        put_pixel(x, SCREEN_HEIGHT-2, 0x09);
         put_pixel(x, SCREEN_HEIGHT-1, 0x0F);
     }
     for(int y=0; y<SCREEN_HEIGHT; y++) {
         put_pixel(0, y, 0x0F);
+        put_pixel(1, y, 0x09);
+        put_pixel(SCREEN_WIDTH-2, y, 0x09);
         put_pixel(SCREEN_WIDTH-1, y, 0x0F);
     }
 }


### PR DESCRIPTION
## Summary
- tune terminal character dimensions for 800x600 graphics
- compute rows and columns from the new sizes
- draw a thicker two-colour border around the terminal

## Testing
- `python3 setup_bootloader.py >build.log` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f8e6e1f74832fac4089b5860b5c36