### PR TITLE
Enable linear framebuffer

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -13,9 +13,19 @@ start:
     mov ss, ax
     mov sp, 0x7C00
 
-    ; Set VESA graphics mode 0x103 (800x600 256 colors)
+    ; Get VESA mode information for 0x103
+    mov ax, 0x4F01
+    mov cx, 0x103
+    mov di, mode_info
+    int 0x10
+    ; Save linear framebuffer address
+    mov si, mode_info
+    mov eax, [si + 0x28]
+    mov [fb_addr], eax
+
+    ; Set VESA graphics mode 0x4103 (800x600 256 colors, linear FB)
     mov ax, 0x4F02
-    mov bx, 0x103
+    mov bx, 0x4103
     int 0x10
 
     ; load kernel (assumes kernel starts at second sector)
@@ -47,6 +57,8 @@ protected_mode:
     mov ss, ax
     mov esp, 0x90000
 
+    mov ebx, [fb_addr]
+
     call dword 0x1000
 .halt:
     hlt
@@ -63,6 +75,9 @@ gdt_end:
 gdt_desc:
     dw gdt_end - gdt_start - 1
     dd gdt_start
+
+mode_info: times 256 db 0
+fb_addr:   dd 0
 
 BOOT_DRIVE: db 0
 

--- a/OptrixOS-Kernel/asm/kernel.asm
+++ b/OptrixOS-Kernel/asm/kernel.asm
@@ -1,5 +1,6 @@
 BITS 32
 
+extern graphics_set_framebuffer
 extern screen_init
 extern boot_logo
 extern terminal_init
@@ -7,6 +8,9 @@ extern terminal_run
 
 global start
 start:
+    push ebx
+    call graphics_set_framebuffer
+    add esp, 4
     call screen_init
     call boot_logo
     call terminal_init

--- a/OptrixOS-Kernel/include/graphics.h
+++ b/OptrixOS-Kernel/include/graphics.h
@@ -3,4 +3,5 @@
 #include <stdint.h>
 void put_pixel(int x, int y, uint8_t color);
 void draw_rect(int x, int y, int w, int h, uint8_t color);
+void graphics_set_framebuffer(uint32_t addr);
 #endif

--- a/OptrixOS-Kernel/src/graphics.c
+++ b/OptrixOS-Kernel/src/graphics.c
@@ -3,7 +3,11 @@
 
 #define WIDTH 800
 #define HEIGHT 600
-static volatile uint8_t *const VGA = (uint8_t *)0xA0000;
+static volatile uint8_t *VGA = (uint8_t *)0xA0000;
+
+void graphics_set_framebuffer(uint32_t addr) {
+    VGA = (volatile uint8_t *)addr;
+}
 
 void put_pixel(int x, int y, uint8_t color) {
     if (x < 0 || x >= WIDTH || y < 0 || y >= HEIGHT)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ behaviour of the historic `fsboot` loader. When executed it:
 - Loads the kernel from the disk image into memory at `0x1000`.
 - Initializes a simple GDT and switches the CPU to 32-bit protected mode.
 - Jumps to the kernel entry point.
+- Uses the VESA linear framebuffer so the full 800x600 screen is accessible.
 - Bootloader prints progress messages while loading the kernel.
 - Displays a simple spinning logo for a few seconds before launching the
   terminal.


### PR DESCRIPTION
## Summary
- use VESA linear framebuffer to utilise full 800x600 display
- expose graphics_set_framebuffer and call it from kernel start
- propagate LFB address from bootloader

## Testing
- `make -C OptrixOS-Kernel clean all`

------
https://chatgpt.com/codex/tasks/task_e_684f903faab8832fad3fd35dc81f315b