### PR TITLE
Improve terminal border and basic directory management

### DIFF
--- a/OptrixOS-Kernel/include/fs.h
+++ b/OptrixOS-Kernel/include/fs.h
@@ -12,6 +12,7 @@ typedef struct fs_entry {
 
 fs_entry* fs_find_entry(fs_entry* dir, const char* name);
 fs_entry* fs_create_file(fs_entry* dir, const char* name);
+fs_entry* fs_create_dir(fs_entry* dir, const char* name);
 int fs_delete_entry(fs_entry* dir, const char* name);
 
 void fs_init(void);

--- a/OptrixOS-Kernel/src/boot_logo.c
+++ b/OptrixOS-Kernel/src/boot_logo.c
@@ -2,10 +2,16 @@
 #include <stdint.h>
 
 void boot_logo(void) {
+    const char *msg = "OptrixOS booting...";
+    int msg_len = 18; /* length of message */
+    int start_col = (SCREEN_COLS - msg_len) / 2;
+    for(int i=0; i<msg_len; i++)
+        screen_put_char(start_col + i, SCREEN_ROWS/2 - 1, msg[i], 0x0A);
+
     const char frames[] = "|/-\\";
     for(int t=0; t<20; t++) {
         for(int f=0; f<4; f++) {
-            screen_put_char(SCREEN_COLS/2, SCREEN_ROWS/2, frames[f], 0x0E);
+            screen_put_char(SCREEN_COLS/2, SCREEN_ROWS/2 + 1, frames[f], 0x0E);
             for(volatile int d=0; d<1000000; d++); /* crude delay */
         }
     }

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -9,7 +9,7 @@ static int streq(const char* a, const char* b) {
     return *a == *b;
 }
 
-#define MAX_ROOT_ENTRIES 10
+#define MAX_ROOT_ENTRIES 20
 static fs_entry root_entries[MAX_ROOT_ENTRIES];
 static int root_count = 0;
 
@@ -22,6 +22,11 @@ static fs_entry docs_entries[MAX_DOC_ENTRIES];
 static int docs_count = 0;
 
 static fs_entry root_dir = {"/", 1, NULL, root_entries, 0, ""};
+
+#define MAX_EXTRA_DIRS 5
+#define MAX_EXTRA_DIR_ENTRIES 5
+static fs_entry extra_dir_entries[MAX_EXTRA_DIRS][MAX_EXTRA_DIR_ENTRIES];
+static int extra_dir_used = 0;
 
 fs_entry* fs_get_root(void) {
     return &root_dir;
@@ -73,6 +78,22 @@ fs_entry* fs_create_file(fs_entry* dir, const char* name) {
     e->children = NULL;
     e->child_count = 0;
     e->content[0]='\0';
+    return e;
+}
+
+fs_entry* fs_create_dir(fs_entry* dir, const char* name) {
+    if(dir->child_count >= MAX_ROOT_ENTRIES) return 0;
+    if(extra_dir_used >= MAX_EXTRA_DIRS) return 0;
+    fs_entry* e = &dir->children[dir->child_count++];
+    for(int i=0;i<32;i++){e->name[i]=0;}
+    int idx=0; while(name[idx] && idx<31){ e->name[idx]=name[idx]; idx++; }
+    e->name[idx]='\0';
+    e->is_dir = 1;
+    e->parent = dir;
+    e->children = extra_dir_entries[extra_dir_used];
+    e->child_count = 0;
+    e->content[0]='\0';
+    extra_dir_used++;
     return e;
 }
 

--- a/OptrixOS-Kernel/src/screen.c
+++ b/OptrixOS-Kernel/src/screen.c
@@ -9,17 +9,19 @@ void screen_clear(void) {
 }
 
 static void draw_border(void) {
+    /* Slightly thicker border with light grey outer line and
+       cyan inner line for a cleaner look */
     for(int x=0; x<SCREEN_WIDTH; x++) {
-        put_pixel(x, 0, 0x0F);
-        put_pixel(x, 1, 0x09);
-        put_pixel(x, SCREEN_HEIGHT-2, 0x09);
-        put_pixel(x, SCREEN_HEIGHT-1, 0x0F);
+        put_pixel(x, 0, 0x07);               /* outer */
+        put_pixel(x, 1, 0x0B);               /* inner */
+        put_pixel(x, SCREEN_HEIGHT-2, 0x0B);
+        put_pixel(x, SCREEN_HEIGHT-1, 0x07);
     }
     for(int y=0; y<SCREEN_HEIGHT; y++) {
-        put_pixel(0, y, 0x0F);
-        put_pixel(1, y, 0x09);
-        put_pixel(SCREEN_WIDTH-2, y, 0x09);
-        put_pixel(SCREEN_WIDTH-1, y, 0x0F);
+        put_pixel(0, y, 0x07);
+        put_pixel(1, y, 0x0B);
+        put_pixel(SCREEN_WIDTH-2, y, 0x0B);
+        put_pixel(SCREEN_WIDTH-1, y, 0x07);
     }
 }
 

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -185,6 +185,8 @@ static void cmd_help(void) {
     print("write <file> <text> - write text to file\n");
     print("rm <file>   - delete file\n");
     print("mv <a> <b>  - rename file\n");
+    print("mkdir <name> - create directory\n");
+    print("rmdir <name> - remove directory\n");
     print("date       - show build date\n");
     print("whoami     - display current user\n");
     print("hello      - greet the user\n");
@@ -358,6 +360,30 @@ static void cmd_touch(const char* name) {
     }
 }
 
+static void cmd_mkdir(const char* name) {
+    if(fs_find_entry(current_dir, name)) {
+        print("Entry exists\n");
+        return;
+    }
+    if(fs_create_dir(current_dir, name)) {
+        print("Directory created\n");
+    } else {
+        print("Cannot create directory\n");
+    }
+}
+
+static void cmd_rmdir(const char* name) {
+    fs_entry* d = fs_find_entry(current_dir, name);
+    if(d && d->is_dir && d->child_count==0) {
+        if(fs_delete_entry(current_dir, name))
+            print("Directory removed\n");
+        else
+            print("Error removing directory\n");
+    } else {
+        print("Directory not empty or not found\n");
+    }
+}
+
 static void cmd_write(const char* args) {
     int i=0;
     while(args[i] && args[i]!=' ') i++;
@@ -436,6 +462,10 @@ static void execute(const char* line) {
         cmd_rm(line+3);
     } else if(strprefix(line, "mv ")) {
         cmd_mv(line+3);
+    } else if(strprefix(line, "mkdir ")) {
+        cmd_mkdir(line+6);
+    } else if(strprefix(line, "rmdir ")) {
+        cmd_rmdir(line+6);
     } else if(streq(line, "date")) {
         cmd_date();
     } else if(streq(line, "whoami")) {

--- a/README.md
+++ b/README.md
@@ -77,4 +77,6 @@ The following commands are implemented:
 * `write`   - write text to a file
 * `rm`      - delete a file
 * `mv`      - rename a file
+* `mkdir`   - create a directory
+* `rmdir`   - remove an empty directory
 


### PR DESCRIPTION
## Summary
- restyle terminal border for a sleeker look
- show a short boot message before the terminal
- extend in‑memory filesystem to allow creation of small directories
- add `mkdir` and `rmdir` commands
- document new commands

## Testing
- `python3 setup_bootloader.py` *(fails: `mkisofs` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850663e4b98832fada7a01f128103ba