### PR TITLE
Improve terminal look and directory support

### DIFF
--- a/OptrixOS-Kernel/include/screen.h
+++ b/OptrixOS-Kernel/include/screen.h
@@ -12,6 +12,8 @@
 #define SCREEN_COLS ((SCREEN_WIDTH - 2*OFFSET_X) / CHAR_WIDTH)
 #define SCREEN_ROWS ((SCREEN_HEIGHT - 2*OFFSET_Y) / CHAR_HEIGHT)
 
+#define BACKGROUND_COLOR 0x0F
+
 void screen_init(void);
 void screen_clear(void);
 void screen_put_char(int col, int row, char c, uint8_t color);

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -23,8 +23,8 @@ static int docs_count = 0;
 
 static fs_entry root_dir = {"/", 1, NULL, root_entries, 0, ""};
 
-#define MAX_EXTRA_DIRS 5
-#define MAX_EXTRA_DIR_ENTRIES 5
+#define MAX_EXTRA_DIRS 20
+#define MAX_EXTRA_DIR_ENTRIES 20
 static fs_entry extra_dir_entries[MAX_EXTRA_DIRS][MAX_EXTRA_DIR_ENTRIES];
 static int extra_dir_used = 0;
 
@@ -68,7 +68,8 @@ fs_entry* fs_find_entry(fs_entry* dir, const char* name) {
 }
 
 fs_entry* fs_create_file(fs_entry* dir, const char* name) {
-    if(dir->child_count >= MAX_ROOT_ENTRIES) return 0;
+    int limit = (dir == &root_dir) ? MAX_ROOT_ENTRIES : MAX_EXTRA_DIR_ENTRIES;
+    if(dir->child_count >= limit) return 0;
     fs_entry* e = &dir->children[dir->child_count++];
     for(int i=0;i<32;i++){e->name[i]=0;}
     int idx=0; while(name[idx] && idx<31){ e->name[idx]=name[idx]; idx++; }
@@ -82,7 +83,8 @@ fs_entry* fs_create_file(fs_entry* dir, const char* name) {
 }
 
 fs_entry* fs_create_dir(fs_entry* dir, const char* name) {
-    if(dir->child_count >= MAX_ROOT_ENTRIES) return 0;
+    int limit = (dir == &root_dir) ? MAX_ROOT_ENTRIES : MAX_EXTRA_DIR_ENTRIES;
+    if(dir->child_count >= limit) return 0;
     if(extra_dir_used >= MAX_EXTRA_DIRS) return 0;
     fs_entry* e = &dir->children[dir->child_count++];
     for(int i=0;i<32;i++){e->name[i]=0;}

--- a/OptrixOS-Kernel/src/screen.c
+++ b/OptrixOS-Kernel/src/screen.c
@@ -5,23 +5,22 @@
 
 
 void screen_clear(void) {
-    draw_rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, 0x00);
+    draw_rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, BACKGROUND_COLOR);
 }
 
 static void draw_border(void) {
-    /* Slightly thicker border with light grey outer line and
-       cyan inner line for a cleaner look */
+    /* Simple black border on white background */
     for(int x=0; x<SCREEN_WIDTH; x++) {
-        put_pixel(x, 0, 0x07);               /* outer */
-        put_pixel(x, 1, 0x0B);               /* inner */
-        put_pixel(x, SCREEN_HEIGHT-2, 0x0B);
-        put_pixel(x, SCREEN_HEIGHT-1, 0x07);
+        put_pixel(x, 0, 0x00);               /* outer */
+        put_pixel(x, 1, 0x00);               /* inner */
+        put_pixel(x, SCREEN_HEIGHT-2, 0x00);
+        put_pixel(x, SCREEN_HEIGHT-1, 0x00);
     }
     for(int y=0; y<SCREEN_HEIGHT; y++) {
-        put_pixel(0, y, 0x07);
-        put_pixel(1, y, 0x0B);
-        put_pixel(SCREEN_WIDTH-2, y, 0x0B);
-        put_pixel(SCREEN_WIDTH-1, y, 0x07);
+        put_pixel(0, y, 0x00);
+        put_pixel(1, y, 0x00);
+        put_pixel(SCREEN_WIDTH-2, y, 0x00);
+        put_pixel(SCREEN_WIDTH-1, y, 0x00);
     }
 }
 
@@ -36,7 +35,7 @@ void screen_put_char(int col, int row, char c, uint8_t color) {
             if(line & (1 << ((cx * 8) / CHAR_WIDTH)))
                 put_pixel(x+cx, y+cy, color);
             else
-                put_pixel(x+cx, y+cy, 0x00);
+                put_pixel(x+cx, y+cy, BACKGROUND_COLOR);
         }
     }
 }

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -10,8 +10,9 @@ static int strprefix(const char* str, const char* pre) { while(*pre) { if(*str!=
 
 #define WIDTH SCREEN_COLS
 #define HEIGHT SCREEN_ROWS
-#define DEFAULT_TEXT_COLOR 0x0B
+#define DEFAULT_TEXT_COLOR 0x00
 #define CURSOR_COLOR 0x0E
+#define BACKGROUND_COLOR 0x0F
 #define CURSOR_CHAR '_'
 
 static char text_buffer[HEIGHT][WIDTH];
@@ -47,8 +48,8 @@ static void scroll(void) {
     }
     for(int x=0; x<WIDTH; x++) {
         text_buffer[HEIGHT-1][x] = ' ';
-        color_buffer[HEIGHT-1][x] = 0x00;
-        screen_put_char(x, HEIGHT-1, ' ', 0x00);
+        color_buffer[HEIGHT-1][x] = BACKGROUND_COLOR;
+        screen_put_char(x, HEIGHT-1, ' ', BACKGROUND_COLOR);
     }
 }
 
@@ -75,7 +76,7 @@ static void putchar(char c) {
 void terminal_init(void) {
     for(int y=0; y<HEIGHT; y++)
         for(int x=0; x<WIDTH; x++)
-            put_entry_at(' ', 0x00, x, y);
+            put_entry_at(' ', BACKGROUND_COLOR, x, y);
     row = 0;
     col = 0;
     draw_cursor(1);
@@ -146,7 +147,7 @@ static void read_line(char* buf, size_t max) {
                     col--;
                 }
                 idx--;
-                put_entry_at(' ', 0x00, col, row);
+                put_entry_at(' ', BACKGROUND_COLOR, col, row);
                 draw_cursor(1);
             }
             continue;
@@ -196,7 +197,7 @@ static void cmd_help(void) {
 static void cmd_clear(void) {
     for(int y=0; y<HEIGHT; y++)
         for(int x=0; x<WIDTH; x++)
-            put_entry_at(' ', 0x00, x, y);
+            put_entry_at(' ', BACKGROUND_COLOR, x, y);
     row=0; col=0;
 }
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ qemu-system-x86_64 -hda disk.img
 After boot a simple text terminal is available. The screen now runs in a
 high‑resolution 800x600 graphics mode with characters rendered at a 21‑pixel
 size. A title bar with a box-drawing border is drawn using VGA graphics
-characters. The background is black with cyan text while the cursor is
-rendered in bright red. The hardware text mode cursor is disabled so only the
+characters. The background is white with black text while the cursor is
+rendered in bright yellow. The hardware text mode cursor is disabled so only the
 custom cursor is visible. The terminal automatically scrolls as it fills.
 The following commands are implemented:
 
@@ -79,4 +79,5 @@ The following commands are implemented:
 * `mv`      - rename a file
 * `mkdir`   - create a directory
 * `rmdir`   - remove an empty directory
+  (directory capacity has been increased to support more entries)
 


### PR DESCRIPTION
## Summary
- switch screen background to white and adjust border
- use white background when printing characters and initialize buffers
- default text color set to black
- enlarge directory table and respect per-directory limits
- document new colors and directory capacity

## Testing
- `make` in `OptrixOS-Kernel`
- `python3 setup_bootloader.py` *(fails: `mkisofs` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685070a80a18832f87e16497542a13ff