### PR TITLE
Improve terminal colors and filesystem initialization

### DIFF
--- a/OptrixOS-Kernel/include/screen.h
+++ b/OptrixOS-Kernel/include/screen.h
@@ -12,7 +12,7 @@
 #define SCREEN_COLS ((SCREEN_WIDTH - 2*OFFSET_X) / CHAR_WIDTH)
 #define SCREEN_ROWS ((SCREEN_HEIGHT - 2*OFFSET_Y) / CHAR_HEIGHT)
 
-#define BACKGROUND_COLOR 0x0F
+#define BACKGROUND_COLOR 0x00
 
 void screen_init(void);
 void screen_clear(void);

--- a/OptrixOS-Kernel/src/screen.c
+++ b/OptrixOS-Kernel/src/screen.c
@@ -9,18 +9,20 @@ void screen_clear(void) {
 }
 
 static void draw_border(void) {
-    /* Simple black border on white background */
+    /* Fancy white border with a grey inner line */
+    const uint8_t outer = 0x0F; /* bright white */
+    const uint8_t inner = 0x08; /* light grey  */
     for(int x=0; x<SCREEN_WIDTH; x++) {
-        put_pixel(x, 0, 0x00);               /* outer */
-        put_pixel(x, 1, 0x00);               /* inner */
-        put_pixel(x, SCREEN_HEIGHT-2, 0x00);
-        put_pixel(x, SCREEN_HEIGHT-1, 0x00);
+        put_pixel(x, 0, outer);
+        put_pixel(x, 1, inner);
+        put_pixel(x, SCREEN_HEIGHT-2, inner);
+        put_pixel(x, SCREEN_HEIGHT-1, outer);
     }
     for(int y=0; y<SCREEN_HEIGHT; y++) {
-        put_pixel(0, y, 0x00);
-        put_pixel(1, y, 0x00);
-        put_pixel(SCREEN_WIDTH-2, y, 0x00);
-        put_pixel(SCREEN_WIDTH-1, y, 0x00);
+        put_pixel(0, y, outer);
+        put_pixel(1, y, inner);
+        put_pixel(SCREEN_WIDTH-2, y, inner);
+        put_pixel(SCREEN_WIDTH-1, y, outer);
     }
 }
 

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -10,9 +10,9 @@ static int strprefix(const char* str, const char* pre) { while(*pre) { if(*str!=
 
 #define WIDTH SCREEN_COLS
 #define HEIGHT SCREEN_ROWS
-#define DEFAULT_TEXT_COLOR 0x00
+#define DEFAULT_TEXT_COLOR 0x0F
 #define CURSOR_COLOR 0x0E
-#define BACKGROUND_COLOR 0x0F
+#define BACKGROUND_COLOR 0x00
 #define CURSOR_CHAR '_'
 
 static char text_buffer[HEIGHT][WIDTH];
@@ -22,6 +22,8 @@ static int row = 0;
 static int col = 0;
 static int cursor_on = 0;
 static uint8_t text_color = DEFAULT_TEXT_COLOR;
+static fs_entry* current_dir;
+static char current_path[32] = "/";
 
 static void draw_cursor(int visible) {
     if(visible)
@@ -81,6 +83,9 @@ void terminal_init(void) {
     col = 0;
     draw_cursor(1);
     fs_init();
+    current_dir = fs_get_root();
+    current_path[0] = '/';
+    current_path[1] = '\0';
 }
 
 static void print(const char* str) {
@@ -285,9 +290,6 @@ static void cmd_uptime(void) {
 }
 
 #include "fs.h"
-
-static fs_entry* current_dir;
-static char current_path[32] = "/";
 
 static void cmd_dir(void) {
     for(int i=0; i<current_dir->child_count; i++) {


### PR DESCRIPTION
## Summary
- initialize the current directory in `terminal_init`
- switch terminal colors to white-on-black
- draw a two-tone border around the screen

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs missing)*

------
https://chatgpt.com/codex/tasks/task_e_6850728f7e38832f83d92610408f27ee