### PR TITLE
Add fs read/write helpers and enforce quoted writes

### DIFF
--- a/OptrixOS-Kernel/include/fs.h
+++ b/OptrixOS-Kernel/include/fs.h
@@ -15,6 +15,12 @@ fs_entry* fs_create_file(fs_entry* dir, const char* name);
 fs_entry* fs_create_dir(fs_entry* dir, const char* name);
 int fs_delete_entry(fs_entry* dir, const char* name);
 
+/* Write text content to a file entry. Text is truncated to 255 chars. */
+void fs_write_file(fs_entry* file, const char* text);
+
+/* Read the content of a file entry. Returns empty string for directories */
+const char* fs_read_file(fs_entry* file);
+
 void fs_init(void);
 fs_entry* fs_get_root(void);
 fs_entry* fs_find_subdir(fs_entry* dir, const char* name);

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -110,3 +110,18 @@ int fs_delete_entry(fs_entry* dir, const char* name) {
     }
     return 0;
 }
+
+void fs_write_file(fs_entry* file, const char* text) {
+    if(!file || file->is_dir) return;
+    int k = 0;
+    while(text[k] && k < 255) {
+        file->content[k] = text[k];
+        k++;
+    }
+    file->content[k] = '\0';
+}
+
+const char* fs_read_file(fs_entry* file) {
+    if(!file || file->is_dir) return "";
+    return file->content;
+}


### PR DESCRIPTION
## Summary
- add filesystem read/write helpers
- enforce quoted text for write command
- use new helpers in terminal

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6850746f40a4832fa9062c246bf11fec