### PR TITLE
Pass framebuffer info to kernel and update run instructions

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -13,15 +13,21 @@ start:
     mov ss, ax
     mov sp, 0x7C00
 
-    ; Get VESA mode information for 0x144 (1920x1080, 256 colors)
+    ; Get VESA mode information for 0x144 (1920x1080, 24/32bpp)
     mov ax, 0x4F01
     mov cx, 0x144
     mov di, mode_info
     int 0x10
-    ; Save linear framebuffer address
+    ; Save framebuffer parameters for the kernel
     mov si, mode_info
     mov eax, [si + 0x28]
     mov [fb_addr], eax
+    mov ax, [si + 0x12]    ; XResolution
+    mov [fb_width], ax
+    mov ax, [si + 0x14]    ; YResolution
+    mov [fb_height], ax
+    mov al, [si + 0x19]    ; BitsPerPixel
+    mov [fb_bpp], al
 
     ; Set VESA graphics mode 0x4144 (1920x1080 256 colors, linear FB)
     mov ax, 0x4F02
@@ -58,6 +64,9 @@ protected_mode:
     mov esp, 0x90000
 
     mov ebx, [fb_addr]
+    mov ecx, [fb_width]
+    mov edx, [fb_height]
+    mov esi, [fb_bpp]
 
     call dword 0x1000
 .halt:
@@ -78,6 +87,9 @@ gdt_desc:
 
 mode_info: times 256 db 0
 fb_addr:   dd 0
+fb_width:  dw 0
+fb_height: dw 0
+fb_bpp:    db 0
 
 BOOT_DRIVE: db 0
 

--- a/OptrixOS-Kernel/asm/kernel.asm
+++ b/OptrixOS-Kernel/asm/kernel.asm
@@ -1,6 +1,7 @@
 BITS 32
 
 extern graphics_set_framebuffer
+extern graphics_init
 extern screen_init
 extern boot_logo
 extern terminal_init
@@ -11,6 +12,11 @@ start:
     push ebx
     call graphics_set_framebuffer
     add esp, 4
+    push esi
+    push edx
+    push ecx
+    call graphics_init
+    add esp, 12
     call screen_init
     call boot_logo
     call terminal_init

--- a/OptrixOS-Kernel/include/graphics.h
+++ b/OptrixOS-Kernel/include/graphics.h
@@ -1,7 +1,11 @@
 #ifndef GRAPHICS_H
 #define GRAPHICS_H
 #include <stdint.h>
+void graphics_set_framebuffer(uint32_t addr);
+void graphics_init(int width, int height, int bpp);
 void put_pixel(int x, int y, uint8_t color);
 void draw_rect(int x, int y, int w, int h, uint8_t color);
-void graphics_set_framebuffer(uint32_t addr);
+extern int FB_WIDTH;
+extern int FB_HEIGHT;
+extern int FB_BPP;
 #endif

--- a/OptrixOS-Kernel/src/graphics.c
+++ b/OptrixOS-Kernel/src/graphics.c
@@ -1,18 +1,39 @@
 #include "graphics.h"
 #include <stdint.h>
 
-#define WIDTH 1920
-#define HEIGHT 1080
+int FB_WIDTH = 0;
+int FB_HEIGHT = 0;
+int FB_BPP = 1;
 static volatile uint8_t *VGA = (uint8_t *)0xA0000;
 
 void graphics_set_framebuffer(uint32_t addr) {
     VGA = (volatile uint8_t *)addr;
 }
 
+void graphics_init(int width, int height, int bpp) {
+    FB_WIDTH = width;
+    FB_HEIGHT = height;
+    FB_BPP = bpp / 8;
+    if(FB_BPP <= 0) FB_BPP = 1;
+}
+
 void put_pixel(int x, int y, uint8_t color) {
-    if (x < 0 || x >= WIDTH || y < 0 || y >= HEIGHT)
+    if (x < 0 || x >= FB_WIDTH || y < 0 || y >= FB_HEIGHT)
         return;
-    VGA[y * WIDTH + x] = color;
+    uint32_t offset = (y * FB_WIDTH + x) * FB_BPP;
+    if(FB_BPP == 1) {
+        VGA[offset] = color;
+    } else if(FB_BPP == 2) {
+        ((uint16_t*)VGA)[y * FB_WIDTH + x] = color;
+    } else {
+        static const uint32_t palette[16] = {
+            0x000000,0x0000AA,0x00AA00,0x00AAAA,
+            0xAA0000,0xAA00AA,0xAA5500,0xAAAAAA,
+            0x555555,0x5555FF,0x55FF55,0x55FFFF,
+            0xFF5555,0xFF55FF,0xFFFF55,0xFFFFFF
+        };
+        ((uint32_t*)VGA)[y * FB_WIDTH + x] = palette[color & 0x0F];
+    }
 }
 
 void draw_rect(int x, int y, int w, int h, uint8_t color) {

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If `mkisofs` is available an ISO named `OptrixOS.iso` is created. Otherwise the
 script outputs `disk.img` which can be run with:
 
 ```bash
-qemu-system-x86_64 -hda disk.img
+qemu-system-x86_64 -vga std -g 1920x1080x32 -hda disk.img
 ```
 
 ## Built-in terminal


### PR DESCRIPTION
## Summary
- pass width/height/bpp from bootloader to kernel
- init graphics with dynamic framebuffer info
- map colors when running in 24/32‑bpp mode
- document running QEMU with a 1920x1080 window

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_685085ce9290832f8b53c318995e6fed