### PR TITLE
Restore 800x600 video mode

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -13,9 +13,9 @@ start:
     mov ss, ax
     mov sp, 0x7C00
 
-    ; Get VESA mode information for 0x144 (1920x1080, 24/32bpp)
+    ; Get VESA mode information for 0x103 (800x600, 256 colors)
     mov ax, 0x4F01
-    mov cx, 0x144
+    mov cx, 0x103
     mov di, mode_info
     int 0x10
     ; Save framebuffer parameters for the kernel
@@ -29,9 +29,9 @@ start:
     mov al, [si + 0x19]    ; BitsPerPixel
     mov [fb_bpp], al
 
-    ; Set VESA graphics mode 0x4144 (1920x1080 256 colors, linear FB)
+    ; Set VESA graphics mode 0x4103 (800x600 256 colors, linear FB)
     mov ax, 0x4F02
-    mov bx, 0x4144
+    mov bx, 0x4103
     int 0x10
 
     ; load kernel (assumes kernel starts at second sector)

--- a/OptrixOS-Kernel/include/screen.h
+++ b/OptrixOS-Kernel/include/screen.h
@@ -3,10 +3,10 @@
 
 #include <stdint.h>
 
-#define SCREEN_WIDTH 1920
-#define SCREEN_HEIGHT 1080
-#define CHAR_WIDTH 8
-#define CHAR_HEIGHT 8
+#define SCREEN_WIDTH 800
+#define SCREEN_HEIGHT 600
+#define CHAR_WIDTH 12
+#define CHAR_HEIGHT 16
 #define OFFSET_X 8
 #define OFFSET_Y 8
 #define SCREEN_COLS ((SCREEN_WIDTH - 2*OFFSET_X) / CHAR_WIDTH)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ behaviour of the historic `fsboot` loader. When executed it:
 - Loads the kernel from the disk image into memory at `0x1000`.
 - Initializes a simple GDT and switches the CPU to 32-bit protected mode.
 - Jumps to the kernel entry point.
-- Uses the VESA linear framebuffer so the full 1920x1080 screen is accessible.
+- Uses the VESA linear framebuffer so the full 800x600 screen is accessible.
 - Bootloader prints progress messages while loading the kernel.
 - Displays a simple spinning logo for a few seconds before launching the
   terminal.
@@ -43,14 +43,14 @@ If `mkisofs` is available an ISO named `OptrixOS.iso` is created. Otherwise the
 script outputs `disk.img` which can be run with:
 
 ```bash
-qemu-system-x86_64 -vga std -g 1920x1080x32 -hda disk.img
+qemu-system-x86_64 -vga std -g 800x600x32 -hda disk.img
 ```
 
 ## Built-in terminal
 
 After boot a simple text terminal is available. The screen now runs in a
-high‑resolution 1920x1080 graphics mode with characters rendered at an
-8‑pixel size. A title bar with a box-drawing border is drawn using VGA graphics
+high‑resolution 800x600 graphics mode with characters rendered at a 21‑pixel
+size. A title bar with a box-drawing border is drawn using VGA graphics
 characters. The background is white with black text while the cursor is
 rendered in bright yellow. The hardware text mode cursor is disabled so only the
 custom cursor is visible. The terminal automatically scrolls as it fills.


### PR DESCRIPTION
## Summary
- revert framebuffer settings back to 800x600
- update screen constants to match the original resolution
- adjust README instructions for the smaller resolution

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs.exe not found)*
- `make -C OptrixOS-Kernel all`

------
https://chatgpt.com/codex/tasks/task_e_685088f17d74832fa23a6944bec4c7b7