### PR TITLE
Add simple desktop and mouse stubs

### DIFF
--- a/OptrixOS-Kernel/asm/kernel.asm
+++ b/OptrixOS-Kernel/asm/kernel.asm
@@ -3,9 +3,8 @@ BITS 32
 extern graphics_set_framebuffer
 extern screen_init
 extern boot_logo
-extern login_prompt
-extern terminal_init
-extern terminal_run
+extern desktop_init
+extern desktop_run
 
 global start
 start:
@@ -14,9 +13,8 @@ start:
     add esp, 4
     call screen_init
     call boot_logo
-    call login_prompt
-    call terminal_init
-    call terminal_run
+    call desktop_init
+    call desktop_run
 .halt:
     hlt
     jmp .halt

--- a/OptrixOS-Kernel/include/desktop.h
+++ b/OptrixOS-Kernel/include/desktop.h
@@ -1,0 +1,7 @@
+#ifndef DESKTOP_H
+#define DESKTOP_H
+
+void desktop_init(void);
+void desktop_run(void);
+
+#endif

--- a/OptrixOS-Kernel/include/mouse.h
+++ b/OptrixOS-Kernel/include/mouse.h
@@ -1,0 +1,10 @@
+#ifndef MOUSE_H
+#define MOUSE_H
+
+void mouse_init(void);
+void mouse_update(void);
+int mouse_get_x(void);
+int mouse_get_y(void);
+int mouse_clicked(void);
+
+#endif

--- a/OptrixOS-Kernel/include/window.h
+++ b/OptrixOS-Kernel/include/window.h
@@ -1,0 +1,13 @@
+#ifndef WINDOW_H
+#define WINDOW_H
+
+#include <stdint.h>
+
+typedef struct {
+    int x, y, w, h;
+    int visible;
+} window_t;
+
+void window_draw(window_t* win, uint8_t color);
+
+#endif

--- a/OptrixOS-Kernel/src/desktop.c
+++ b/OptrixOS-Kernel/src/desktop.c
@@ -1,0 +1,61 @@
+#include "desktop.h"
+#include "screen.h"
+#include "graphics.h"
+#include "mouse.h"
+#include "terminal.h"
+#include "window.h"
+
+static int icon_x = 50;
+static int icon_y = 50;
+static int dragging = 0;
+static int click_timer = 0;
+
+static void draw_icon(void) {
+    draw_rect(icon_x, icon_y, 32, 32, 0x07);
+    screen_put_char((icon_x+12-OFFSET_X)/CHAR_WIDTH, (icon_y+12-OFFSET_Y)/CHAR_HEIGHT, 'T', 0x0F);
+}
+
+static int in_icon(int x, int y) {
+    return (x >= icon_x && x < icon_x+32 && y >= icon_y && y < icon_y+32);
+}
+
+void desktop_init(void) {
+    draw_rect(0,0,SCREEN_WIDTH,SCREEN_HEIGHT,0x17);
+    icon_x = 50;
+    icon_y = 50;
+    draw_icon();
+}
+
+void desktop_run(void) {
+    mouse_init();
+    while(1) {
+        mouse_update();
+        int mx = mouse_get_x();
+        int my = mouse_get_y();
+        if(mouse_clicked()) {
+            if(in_icon(mx,my)) {
+                if(click_timer > 0 && click_timer < 20) {
+                    terminal_init();
+                    terminal_run();
+                    desktop_init();
+                } else {
+                    dragging = 1;
+                    click_timer = 1;
+                }
+            } else {
+                click_timer = 1;
+            }
+        } else {
+            if(dragging) {
+                icon_x = mx-16;
+                icon_y = my-16;
+            }
+            if(click_timer>0) click_timer++;
+            if(click_timer>30) click_timer=0;
+            dragging = 0;
+        }
+        desktop_init();
+        draw_icon();
+        draw_rect(mx-2,my-2,4,4,0x0F);
+    }
+}

--- a/OptrixOS-Kernel/src/mouse.c
+++ b/OptrixOS-Kernel/src/mouse.c
@@ -1,0 +1,32 @@
+#include "mouse.h"
+#include "keyboard.h"
+#include "graphics.h"
+#include "screen.h"
+
+static int mx = SCREEN_WIDTH/2;
+static int my = SCREEN_HEIGHT/2;
+static int clicked = 0;
+
+void mouse_init(void) {
+    mx = SCREEN_WIDTH/2;
+    my = SCREEN_HEIGHT/2;
+    clicked = 0;
+}
+
+void mouse_update(void) {
+    char c = keyboard_getchar();
+    clicked = 0;
+    if(c == 'w') my -= 4;
+    else if(c == 's') my += 4;
+    else if(c == 'a') mx -= 4;
+    else if(c == 'd') mx += 4;
+    else if(c == 'm') clicked = 1;
+    if(mx < 0) mx = 0;
+    if(my < 0) my = 0;
+    if(mx >= SCREEN_WIDTH) mx = SCREEN_WIDTH-1;
+    if(my >= SCREEN_HEIGHT) my = SCREEN_HEIGHT-1;
+}
+
+int mouse_get_x(void) { return mx; }
+int mouse_get_y(void) { return my; }
+int mouse_clicked(void) { return clicked; }

--- a/OptrixOS-Kernel/src/window.c
+++ b/OptrixOS-Kernel/src/window.c
@@ -1,0 +1,7 @@
+#include "window.h"
+#include "graphics.h"
+
+void window_draw(window_t* win, uint8_t color) {
+    if(!win || !win->visible) return;
+    draw_rect(win->x, win->y, win->w, win->h, color);
+}


### PR DESCRIPTION
## Summary
- add a placeholder mouse driver
- create minimal window and desktop modules
- change kernel entry to launch the desktop instead of the terminal

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_685090a1aaa0832f98a4eec2e35e0a89