### PR TITLE
Improve windowing and add executable system

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -5,7 +5,7 @@ all: disk.img
 bootloader.bin: asm/bootloader.asm
 	@nasm -f bin $< -o $@
 	
-kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/terminal.o src/fs.o src/boot_logo.o src/login.o
+kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/terminal.o src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o src/window.o src/exec.o
 	@nasm -f elf32 asm/kernel.asm -o kernel_asm.o
 	@nasm -f elf32 asm/ports.asm -o ports.o
 	@gcc $(CFLAGS) -c src/graphics.c -o src/graphics.o
@@ -15,7 +15,14 @@ kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboar
 	@gcc $(CFLAGS) -c src/fs.c -o src/fs.o
 	@gcc $(CFLAGS) -c src/boot_logo.c -o src/boot_logo.o
 	@gcc $(CFLAGS) -c src/login.c -o src/login.o
-	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o src/graphics.o src/screen.o src/keyboard.o src/terminal.o src/fs.o src/boot_logo.o src/login.o --oformat binary -o $@
+	@gcc $(CFLAGS) -c src/desktop.c -o src/desktop.o
+	@gcc $(CFLAGS) -c src/mouse.c -o src/mouse.o
+	@gcc $(CFLAGS) -c src/window.c -o src/window.o
+	@gcc $(CFLAGS) -c src/exec.c -o src/exec.o
+	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
+	    src/graphics.o src/screen.o src/keyboard.o src/terminal.o \
+	    src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o \
+	    src/window.o src/exec.o --oformat binary -o $@
 	
 disk.img: bootloader.bin kernel.bin
 	@cat bootloader.bin kernel.bin > $@

--- a/OptrixOS-Kernel/include/exec.h
+++ b/OptrixOS-Kernel/include/exec.h
@@ -1,0 +1,12 @@
+#ifndef EXEC_H
+#define EXEC_H
+
+#include "window.h"
+
+typedef void (*exec_func_t)(window_t*);
+
+void exec_init(void);
+void exec_register(const char* name, exec_func_t func);
+int exec_run(const char* name);
+
+#endif

--- a/OptrixOS-Kernel/include/window.h
+++ b/OptrixOS-Kernel/include/window.h
@@ -5,13 +5,17 @@
 
 typedef struct {
     int x, y, w, h;
+    int px, py, pw, ph; /* previous position for redraw */
     int visible;
     int state; /* 0=normal,1=max,2=min */
+    uint8_t color;     /* window colour */
+    uint8_t bg_color;  /* background colour behind window */
     const char *title;
 } window_t;
 
-void window_init(window_t *win, int x, int y, int w, int h, const char *title);
-void window_draw(window_t* win, uint8_t color);
+void window_init(window_t *win, int x, int y, int w, int h,
+                 const char *title, uint8_t color, uint8_t bg_color);
+void window_draw(window_t* win);
 void window_handle_mouse(window_t *win, int mx, int my, int click);
 
 #endif

--- a/OptrixOS-Kernel/src/desktop.c
+++ b/OptrixOS-Kernel/src/desktop.c
@@ -4,6 +4,7 @@
 #include "mouse.h"
 #include "terminal.h"
 #include "window.h"
+#include "exec.h"
 
 #define DESKTOP_BG_COLOR 0x17
 
@@ -12,6 +13,12 @@ static int icon_y = 50;
 static int dragging = 0;
 static int click_timer = 0;
 static window_t demo_win;
+
+static void terminal_exec(window_t *win) {
+    (void)win;
+    terminal_init();
+    terminal_run();
+}
 
 static void draw_icon(void) {
     draw_rect(icon_x, icon_y, 32, 32, 0x07);
@@ -27,8 +34,10 @@ void desktop_init(void) {
     icon_x = 50;
     icon_y = 50;
     draw_icon();
-    window_init(&demo_win, 100, 100, 200, 150, "Demo");
-    window_draw(&demo_win, 0x07);
+    exec_init();
+    exec_register("terminal", terminal_exec);
+    window_init(&demo_win, 100, 100, 200, 150, "Demo", 0x07, DESKTOP_BG_COLOR);
+    window_draw(&demo_win);
 }
 
 void desktop_run(void) {
@@ -51,8 +60,7 @@ void desktop_run(void) {
         if(mouse_clicked()) {
             if(in_icon(mx,my)) {
                 if(click_timer > 0 && click_timer < 20) {
-                    terminal_init();
-                    terminal_run();
+                    exec_run("terminal");
                     desktop_init();
                     last_icon_x = icon_x;
                     last_icon_y = icon_y;
@@ -85,7 +93,7 @@ void desktop_run(void) {
         }
 
         window_handle_mouse(&demo_win, mx, my, mouse_clicked());
-        window_draw(&demo_win, 0x07);
+        window_draw(&demo_win);
         draw_rect(mx-2,my-2,4,4,0x0F);
 
         last_mx = mx;

--- a/OptrixOS-Kernel/src/exec.c
+++ b/OptrixOS-Kernel/src/exec.c
@@ -1,0 +1,42 @@
+#include "exec.h"
+#include <stddef.h>
+
+#define MAX_EXECS 5
+
+typedef struct {
+    const char* name;
+    exec_func_t func;
+} exec_entry;
+
+static exec_entry table[MAX_EXECS];
+static int exec_count = 0;
+
+static int streq(const char* a, const char* b) {
+    while(*a && *b) { if(*a!=*b) return 0; a++; b++; }
+    return *a==*b;
+}
+
+void exec_init(void) {
+    exec_count = 0;
+}
+
+void exec_register(const char* name, exec_func_t func) {
+    if(exec_count < MAX_EXECS) {
+        table[exec_count].name = name;
+        table[exec_count].func = func;
+        exec_count++;
+    }
+}
+
+int exec_run(const char* name) {
+    for(int i=0;i<exec_count;i++) {
+        if(streq(table[i].name, name)) {
+            window_t win;
+            window_init(&win, 150, 150, 400, 250, name, 0x07, 0x17);
+            window_draw(&win);
+            table[i].func(&win);
+            return 1;
+        }
+    }
+    return 0;
+}

--- a/OptrixOS-Kernel/src/window.c
+++ b/OptrixOS-Kernel/src/window.c
@@ -8,10 +8,14 @@ static int resize = 0;
 static int prev_mx, prev_my;
 static int saved_x, saved_y, saved_w, saved_h;
 
-void window_init(window_t *win, int x, int y, int w, int h, const char *title) {
+void window_init(window_t *win, int x, int y, int w, int h,
+                 const char *title, uint8_t color, uint8_t bg_color) {
     win->x = x; win->y = y; win->w = w; win->h = h;
+    win->px = x; win->py = y; win->pw = w; win->ph = h;
     win->visible = 1;
     win->state = 0;
+    win->color = color;
+    win->bg_color = bg_color;
     win->title = title;
 }
 
@@ -24,14 +28,20 @@ static void draw_buttons(int x, int y) {
     draw_rect(x-12, y+2, 10, 10, 0x03);
 }
 
-void window_draw(window_t* win, uint8_t color) {
+void window_draw(window_t* win) {
     if(!win || !win->visible) return;
     int x = win->x; int y = win->y; int w = win->w; int h = win->h;
     if(win->state == 1) { x = 0; y = 0; w = SCREEN_WIDTH; h = SCREEN_HEIGHT; }
     if(win->state == 2) return; /* minimized */
 
+    /* clear previous location if window moved */
+    if(x != win->px || y != win->py || w != win->pw || h != win->ph) {
+        draw_rect(win->px, win->py, win->pw, win->ph, win->bg_color);
+        win->px = x; win->py = y; win->pw = w; win->ph = h;
+    }
+
     int show_bar = !(win->state == 1 && mouse_get_y() > 2);
-    draw_rect(x, y, w, h, color);
+    draw_rect(x, y, w, h, win->color);
     if(show_bar) {
         draw_rect(x, y, w, 14, 0x01); /* title bar */
         if(win->title) {


### PR DESCRIPTION
## Summary
- extend `window_t` to track previous position and colors
- redraw windows cleanly when they move
- add a simple executable registration/launcher system
- register the terminal as an executable and open it on icon double-click
- update Makefile and desktop code to use new window features

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_68509620b470832f98a33b1b8b5d4121