### PR TITLE
Improve mouse visibility, modernize UI

### DIFF
--- a/OptrixOS-Kernel/include/graphics.h
+++ b/OptrixOS-Kernel/include/graphics.h
@@ -3,5 +3,6 @@
 #include <stdint.h>
 void put_pixel(int x, int y, uint8_t color);
 void draw_rect(int x, int y, int w, int h, uint8_t color);
+void draw_rounded_rect(int x, int y, int w, int h, int r, uint8_t color);
 void graphics_set_framebuffer(uint32_t addr);
 #endif

--- a/OptrixOS-Kernel/include/keyboard.h
+++ b/OptrixOS-Kernel/include/keyboard.h
@@ -2,4 +2,5 @@
 #define KEYBOARD_H
 void keyboard_update(void);
 char keyboard_getchar(void);
+void keyboard_flush(void);
 #endif

--- a/OptrixOS-Kernel/include/mouse.h
+++ b/OptrixOS-Kernel/include/mouse.h
@@ -1,11 +1,16 @@
 #ifndef MOUSE_H
 #define MOUSE_H
 
+#include <stdint.h>
+
 void mouse_init(void);
 void mouse_update(void);
 int mouse_get_x(void);
 int mouse_get_y(void);
 int mouse_clicked(void);
 int mouse_is_present(void);
+void mouse_set_visible(int vis);
+int mouse_get_visible(void);
+void mouse_draw(uint8_t bg_color);
 
 #endif

--- a/OptrixOS-Kernel/src/desktop.c
+++ b/OptrixOS-Kernel/src/desktop.c
@@ -65,13 +65,10 @@ void desktop_init(void) {
 
 void desktop_run(void) {
     mouse_init();
+    mouse_set_visible(1);
     if(!mouse_is_present())
         ; /* fallback will use keyboard input */
-
-    int last_mx = mouse_get_x();
-    int last_my = mouse_get_y();
-    draw_rect(last_mx-2, last_my-2, 4, 4, 0x0F);
-
+    mouse_draw(DESKTOP_BG_COLOR);
     while(1) {
         mouse_update();
         int mx = mouse_get_x();
@@ -95,15 +92,8 @@ void desktop_run(void) {
             if(click_timer>30){ click_timer=0; last_clicked=-1; }
         }
 
-        if(mx != last_mx || my != last_my) {
-            draw_rect(last_mx-2, last_my-2, 4, 4, DESKTOP_BG_COLOR);
-        }
-
         window_handle_mouse(&demo_win, mx, my, mouse_clicked());
         window_draw(&demo_win);
-        draw_rect(mx-2,my-2,4,4,0x0F);
-
-        last_mx = mx;
-        last_my = my;
+        mouse_draw(DESKTOP_BG_COLOR);
     }
 }

--- a/OptrixOS-Kernel/src/graphics.c
+++ b/OptrixOS-Kernel/src/graphics.c
@@ -22,3 +22,22 @@ void draw_rect(int x, int y, int w, int h, uint8_t color) {
         }
     }
 }
+
+void draw_rounded_rect(int x, int y, int w, int h, int r, uint8_t color) {
+    if(r <= 0) { draw_rect(x, y, w, h, color); return; }
+    /* central rects */
+    draw_rect(x + r, y, w - 2*r, h, color);
+    draw_rect(x, y + r, r, h - 2*r, color);
+    draw_rect(x + w - r, y + r, r, h - 2*r, color);
+
+    for(int dy = 0; dy < r; dy++) {
+        for(int dx = 0; dx < r; dx++) {
+            if(dx*dx + dy*dy <= r*r) {
+                put_pixel(x + r - dx - 1, y + r - dy - 1, color); /* TL */
+                put_pixel(x + w - r + dx, y + r - dy - 1, color);  /* TR */
+                put_pixel(x + r - dx - 1, y + h - r + dy, color);  /* BL */
+                put_pixel(x + w - r + dx, y + h - r + dy, color);  /* BR */
+            }
+        }
+    }
+}

--- a/OptrixOS-Kernel/src/keyboard.c
+++ b/OptrixOS-Kernel/src/keyboard.c
@@ -2,7 +2,7 @@
 #include "ports.h"
 #include <stdint.h>
 
-#define KBUF_SIZE 32
+#define KBUF_SIZE 128
 
 static char kbuf[KBUF_SIZE];
 static int khead = 0;
@@ -71,4 +71,9 @@ char keyboard_getchar(void) {
     char c = kbuf[ktail];
     ktail = (ktail + 1) % KBUF_SIZE;
     return c;
+}
+
+void keyboard_flush(void) {
+    khead = ktail = 0;
+    while(inb(0x64) & 1) inb(0x60);
 }

--- a/OptrixOS-Kernel/src/login.c
+++ b/OptrixOS-Kernel/src/login.c
@@ -3,6 +3,7 @@
 
 /* Simple login prompt shown before terminal starts */
 void login_prompt(void) {
+    keyboard_flush();
     const char *user_msg = "Username: admin";
     const char *pass_msg = "Password: ";
     char input[32];

--- a/OptrixOS-Kernel/src/mouse.c
+++ b/OptrixOS-Kernel/src/mouse.c
@@ -8,6 +8,22 @@ static int mx = SCREEN_WIDTH/2;
 static int my = SCREEN_HEIGHT/2;
 static int clicked = 0;
 static int mouse_present = 0;
+static int cursor_visible = 1;
+static int prev_x = -1, prev_y = -1;
+
+void mouse_set_visible(int vis) { cursor_visible = vis; }
+int mouse_get_visible(void) { return cursor_visible; }
+
+void mouse_draw(uint8_t bg_color) {
+    if(prev_x != -1 && prev_y != -1 && cursor_visible)
+        draw_rect(prev_x-2, prev_y-2, 4, 4, bg_color);
+    if(cursor_visible) {
+        draw_rect(mx-2, my-2, 4, 4, 0x0F);
+        prev_x = mx; prev_y = my;
+    } else {
+        prev_x = prev_y = -1;
+    }
+}
 
 static void mouse_wait_input(void) {
     for(int i=0;i<100000;i++) if(inb(0x64) & 1) return;

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -1,6 +1,7 @@
 #include "terminal.h"
 #include "keyboard.h"
 #include "screen.h"
+#include "mouse.h"
 #include "fs.h"
 #include <stdint.h>
 #include <stddef.h>
@@ -89,6 +90,7 @@ static void putchar(char c) {
 }
 
 void terminal_init(void) {
+    keyboard_flush();
     for(int y=0; y<HEIGHT; y++)
         for(int x=0; x<WIDTH; x++)
             put_entry_at(' ', BACKGROUND_COLOR, x, y);
@@ -137,7 +139,10 @@ static void read_line(char* buf, size_t max) {
     int blink = 0;
     cursor_on = 1;
     draw_cursor(1);
+    mouse_draw(BACKGROUND_COLOR);
     while(idx < max-1) {
+        mouse_update();
+        mouse_draw(BACKGROUND_COLOR);
         char c = keyboard_getchar();
         if(!c) {
             blink++;
@@ -182,6 +187,7 @@ static void read_line(char* buf, size_t max) {
         buf[idx++] = c;
     }
     draw_cursor(0);
+    mouse_draw(BACKGROUND_COLOR);
     buf[idx] = '\0';
 }
 
@@ -540,6 +546,8 @@ static void execute(const char* line) {
 
 void terminal_run(void) {
     char buf[128];
+    mouse_set_visible(1);
+    mouse_draw(BACKGROUND_COLOR);
     while(1) {
         print("> ");
         read_line(buf, sizeof(buf));

--- a/OptrixOS-Kernel/src/window.c
+++ b/OptrixOS-Kernel/src/window.c
@@ -20,12 +20,9 @@ void window_init(window_t *win, int x, int y, int w, int h,
 }
 
 static void draw_buttons(int x, int y) {
-    /* close */
-    draw_rect(x-36, y+2, 10, 10, 0x04);
-    /* minimize */
-    draw_rect(x-24, y+2, 10, 10, 0x02);
-    /* maximize */
-    draw_rect(x-12, y+2, 10, 10, 0x03);
+    draw_rounded_rect(x-36, y+2, 8, 8, 2, 0x04); /* close */
+    draw_rounded_rect(x-24, y+2, 8, 8, 2, 0x02); /* minimize */
+    draw_rounded_rect(x-12, y+2, 8, 8, 2, 0x03); /* maximize */
 }
 
 void window_draw(window_t* win) {
@@ -44,9 +41,9 @@ void window_draw(window_t* win) {
     }
 
     int show_bar = !(win->state == 1 && mouse_get_y() > 2);
-    draw_rect(x, y, w, h, win->color);
+    draw_rounded_rect(x, y, w, h, 6, win->color);
     if(show_bar) {
-        draw_rect(x, y, w, 14, 0x01); /* title bar */
+        draw_rounded_rect(x, y, w, 14, 6, 0x01); /* title bar */
         if(win->title) {
             const char *t = win->title;
             for(int i=0; t[i] && i<20; i++)


### PR DESCRIPTION
## Summary
- add rounded rectangle drawing primitive
- keep mouse cursor visible and allow hiding via API
- enlarge keyboard buffer and add flush helper
- display mouse cursor in terminal and on desktop
- draw windows with rounded corners

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68509b953964832fa4316377929f9393