### PR TITLE
Improve terminal UI scaling and window handling

### DIFF
--- a/OptrixOS-Kernel/include/screen.h
+++ b/OptrixOS-Kernel/include/screen.h
@@ -5,12 +5,14 @@
 
 #define SCREEN_WIDTH 800
 #define SCREEN_HEIGHT 600
-#define CHAR_WIDTH 12
-#define CHAR_HEIGHT 16
+#define BASE_CHAR_SIZE 8
+extern int CHAR_WIDTH;
+extern int CHAR_HEIGHT;
+extern int font_scale;
+extern int SCREEN_COLS;
+extern int SCREEN_ROWS;
 #define OFFSET_X 8
 #define OFFSET_Y 8
-#define SCREEN_COLS ((SCREEN_WIDTH - 2*OFFSET_X) / CHAR_WIDTH)
-#define SCREEN_ROWS ((SCREEN_HEIGHT - 2*OFFSET_Y) / CHAR_HEIGHT)
 
 #define BACKGROUND_COLOR 0x00
 
@@ -19,5 +21,7 @@ void screen_clear(void);
 void screen_put_char(int col, int row, char c, uint8_t color);
 void screen_put_char_offset(int col, int row, char c, uint8_t color,
                             int off_x, int off_y);
+void screen_update_metrics(void);
+void screen_adjust_font_scale(int delta);
 
 #endif

--- a/OptrixOS-Kernel/include/terminal.h
+++ b/OptrixOS-Kernel/include/terminal.h
@@ -2,6 +2,6 @@
 #define TERMINAL_H
 #include "window.h"
 void terminal_init(void);
-void terminal_run(void);
+void terminal_run(window_t *win);
 void terminal_set_window(window_t *win);
 #endif

--- a/OptrixOS-Kernel/src/desktop.c
+++ b/OptrixOS-Kernel/src/desktop.c
@@ -16,12 +16,11 @@ static icon_t icons[MAX_ICONS];
 static int icon_count = 0;
 static int click_timer = 0;
 static int last_clicked = -1;
-static window_t demo_win;
 
 static void terminal_exec(window_t *win) {
     terminal_set_window(win);
     terminal_init();
-    terminal_run();
+    terminal_run(win);
 }
 
 static void draw_icons(void) {
@@ -59,8 +58,6 @@ void desktop_init(void) {
     draw_icons();
     exec_init();
     exec_register("terminal.opt", terminal_exec);
-    window_init(&demo_win, 100, 100, 200, 150, "Demo", 0x07, DESKTOP_BG_COLOR);
-    window_draw(&demo_win);
 }
 
 void desktop_run(void) {
@@ -92,8 +89,6 @@ void desktop_run(void) {
             if(click_timer>30){ click_timer=0; last_clicked=-1; }
         }
 
-        window_handle_mouse(&demo_win, mx, my, mouse_clicked());
-        window_draw(&demo_win);
         mouse_draw(DESKTOP_BG_COLOR);
     }
 }

--- a/OptrixOS-Kernel/src/exec.c
+++ b/OptrixOS-Kernel/src/exec.c
@@ -1,5 +1,6 @@
 #include "exec.h"
 #include <stddef.h>
+#include "screen.h"
 
 #define MAX_EXECS 10
 
@@ -32,7 +33,10 @@ int exec_run(const char* name) {
     for(int i=0;i<exec_count;i++) {
         if(streq(table[i].name, name)) {
             window_t win;
-            window_init(&win, 150, 150, 400, 250, name, 0x07, 0x17);
+            int w = 400, h = 250;
+            int x = (SCREEN_WIDTH - w) / 2;
+            int y = (SCREEN_HEIGHT - h) / 2;
+            window_init(&win, x, y, w, h, name, 0x07, 0x17);
             window_draw(&win);
             table[i].func(&win);
             return 1;

--- a/OptrixOS-Kernel/src/keyboard.c
+++ b/OptrixOS-Kernel/src/keyboard.c
@@ -1,5 +1,6 @@
 #include "keyboard.h"
 #include "ports.h"
+#include "screen.h"
 #include <stdint.h>
 
 #define KBUF_SIZE 128
@@ -59,6 +60,10 @@ void keyboard_update(void) {
             continue;
 
         char c = shift_pressed ? sc_shift[sc] : sc_ascii[sc];
+        if(c == '+' || c == '-') {
+            screen_adjust_font_scale(c == '+' ? 1 : -1);
+            continue;
+        }
         if(c)
             enqueue(c);
     }

--- a/OptrixOS-Kernel/src/screen.c
+++ b/OptrixOS-Kernel/src/screen.c
@@ -3,9 +3,31 @@
 #include "font/font8x8_basic.h"
 #include <stdint.h>
 
+int CHAR_WIDTH = BASE_CHAR_SIZE;
+int CHAR_HEIGHT = BASE_CHAR_SIZE;
+int font_scale = 1;
+int SCREEN_COLS = 0;
+int SCREEN_ROWS = 0;
 
 void screen_clear(void) {
     draw_rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT, BACKGROUND_COLOR);
+}
+
+void screen_update_metrics(void) {
+    CHAR_WIDTH = BASE_CHAR_SIZE * font_scale;
+    CHAR_HEIGHT = BASE_CHAR_SIZE * font_scale;
+    if(CHAR_WIDTH <= 0) CHAR_WIDTH = 1;
+    if(CHAR_HEIGHT <= 0) CHAR_HEIGHT = 1;
+    SCREEN_COLS = (SCREEN_WIDTH - 2*OFFSET_X) / CHAR_WIDTH;
+    SCREEN_ROWS = (SCREEN_HEIGHT - 2*OFFSET_Y) / CHAR_HEIGHT;
+}
+
+void screen_adjust_font_scale(int delta) {
+    font_scale += delta;
+    if(font_scale < 1) font_scale = 1;
+    if(font_scale > 5) font_scale = 5;
+    screen_update_metrics();
+    screen_clear();
 }
 
 static void draw_border(void) {
@@ -60,6 +82,6 @@ void screen_put_char_offset(int col, int row, char c, uint8_t color,
 }
 
 void screen_init(void) {
-    /* The desktop and terminal now start without a decorative border */
+    screen_update_metrics();
     screen_clear();
 }

--- a/OptrixOS-Kernel/src/window.c
+++ b/OptrixOS-Kernel/src/window.c
@@ -63,7 +63,9 @@ void window_handle_mouse(window_t *win, int mx, int my, int click) {
 
     if(click && !drag && !resize) {
         if(show_bar && my >= y && my < y+14 && mx >= x+w-36 && mx < x+w-26) {
+            draw_rect(win->x, win->y, win->w, win->h, win->bg_color);
             win->visible = 0; /* close */
+            win->px = win->py = -1;
             return;
         } else if(show_bar && my >= y && my < y+14 && mx >= x+w-24 && mx < x+w-14) {
             win->state = 2; /* minimize */


### PR DESCRIPTION
## Summary
- add runtime font metrics and global scaling controls
- resize and redraw terminal window dynamically
- center application windows on open
- remove obsolete demo window and handle window close cleanup

## Testing
- `make all`

------
https://chatgpt.com/codex/tasks/task_e_68509df25d4c832f85b2572809bfa538