### PR TITLE
Improve window and cursor redraw

### DIFF
--- a/OptrixOS-Kernel/include/graphics.h
+++ b/OptrixOS-Kernel/include/graphics.h
@@ -2,6 +2,7 @@
 #define GRAPHICS_H
 #include <stdint.h>
 void put_pixel(int x, int y, uint8_t color);
+uint8_t get_pixel(int x, int y);
 void draw_rect(int x, int y, int w, int h, uint8_t color);
 void draw_rounded_rect(int x, int y, int w, int h, int r, uint8_t color);
 void graphics_set_framebuffer(uint32_t addr);

--- a/OptrixOS-Kernel/src/graphics.c
+++ b/OptrixOS-Kernel/src/graphics.c
@@ -15,6 +15,12 @@ void put_pixel(int x, int y, uint8_t color) {
     VGA[y * WIDTH + x] = color;
 }
 
+uint8_t get_pixel(int x, int y) {
+    if (x < 0 || x >= WIDTH || y < 0 || y >= HEIGHT)
+        return 0;
+    return VGA[y * WIDTH + x];
+}
+
 void draw_rect(int x, int y, int w, int h, uint8_t color) {
     for (int j = 0; j < h; j++) {
         for (int i = 0; i < w; i++) {

--- a/OptrixOS-Kernel/src/mouse.c
+++ b/OptrixOS-Kernel/src/mouse.c
@@ -10,14 +10,22 @@ static int clicked = 0;
 static int mouse_present = 0;
 static int cursor_visible = 1;
 static int prev_x = -1, prev_y = -1;
+static uint8_t saved_bg[4][4];
 
 void mouse_set_visible(int vis) { cursor_visible = vis; }
 int mouse_get_visible(void) { return cursor_visible; }
 
 void mouse_draw(uint8_t bg_color) {
-    if(prev_x != -1 && prev_y != -1 && cursor_visible)
-        draw_rect(prev_x-2, prev_y-2, 4, 4, bg_color);
+    (void)bg_color;
+    if(prev_x != -1 && prev_y != -1 && cursor_visible) {
+        for(int dy=0; dy<4; dy++)
+            for(int dx=0; dx<4; dx++)
+                put_pixel(prev_x-2+dx, prev_y-2+dy, saved_bg[dy][dx]);
+    }
     if(cursor_visible) {
+        for(int dy=0; dy<4; dy++)
+            for(int dx=0; dx<4; dx++)
+                saved_bg[dy][dx] = get_pixel(mx-2+dx, my-2+dy);
         draw_rect(mx-2, my-2, 4, 4, 0x0F);
         prev_x = mx; prev_y = my;
     } else {

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -32,8 +32,17 @@ static uint8_t text_color = DEFAULT_TEXT_COLOR;
 static fs_entry* current_dir;
 static char current_path[32] = "/";
 
+static void redraw_buffer(void) {
+    for(int y=0; y<term_rows; y++)
+        for(int x=0; x<term_cols; x++)
+            screen_put_char_offset(x, y, text_buffer[y][x],
+                                  color_buffer[y][x], origin_x, origin_y);
+}
+
 void terminal_set_window(window_t *win) {
     term_window = win;
+    int old_x = origin_x;
+    int old_y = origin_y;
     origin_x = win->x + 2;
     origin_y = win->y + 14;
     int new_cols = (win->w - 4) / CHAR_WIDTH;
@@ -49,6 +58,9 @@ void terminal_set_window(window_t *win) {
                 text_buffer[y][x] = ' ';
                 color_buffer[y][x] = BACKGROUND_COLOR;
             }
+        redraw_buffer();
+    } else if(old_x != origin_x || old_y != origin_y) {
+        redraw_buffer();
     }
 }
 

--- a/OptrixOS-Kernel/src/window.c
+++ b/OptrixOS-Kernel/src/window.c
@@ -20,9 +20,9 @@ void window_init(window_t *win, int x, int y, int w, int h,
 }
 
 static void draw_buttons(int x, int y) {
-    draw_rounded_rect(x-36, y+2, 8, 8, 2, 0x04); /* close */
-    draw_rounded_rect(x-24, y+2, 8, 8, 2, 0x02); /* minimize */
-    draw_rounded_rect(x-12, y+2, 8, 8, 2, 0x03); /* maximize */
+    draw_rounded_rect(x-36, y+3, 6, 6, 3, 0x04); /* close */
+    draw_rounded_rect(x-24, y+3, 6, 6, 3, 0x02); /* minimize */
+    draw_rounded_rect(x-12, y+3, 6, 6, 3, 0x03); /* maximize */
 }
 
 void window_draw(window_t* win) {
@@ -41,7 +41,12 @@ void window_draw(window_t* win) {
     }
 
     int show_bar = !(win->state == 1 && mouse_get_y() > 2);
+    /* shadow */
+    draw_rounded_rect(x+2, y+2, w, h, 6, win->bg_color);
+    /* window body */
     draw_rounded_rect(x, y, w, h, 6, win->color);
+    /* border */
+    draw_rounded_rect(x, y, w, h, 6, 0x08);
     if(show_bar) {
         draw_rounded_rect(x, y, w, 14, 6, 0x01); /* title bar */
         if(win->title) {


### PR DESCRIPTION
## Summary
- add `get_pixel` helper in `graphics`
- restore cursor background properly to avoid trails
- redraw terminal contents when window moves
- refresh window drawing with a shadowed border and rounded controls

## Testing
- `python3 setup_bootloader.py` *(fails: `mkisofs.exe not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850a0a20750832f8ee78109f4897a9b