### PR TITLE
Fix boot drive handling

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -12,6 +12,8 @@ start:
     mov es, ax
     mov ss, ax
     mov sp, 0x7C00
+    ; BIOS passes boot drive in DL. Save it for disk reads
+    mov [BOOT_DRIVE], dl
 
     ; Get VESA mode information for 0x103
     mov ax, 0x4F01


### PR DESCRIPTION
## Summary
- store BIOS boot drive before loading the kernel

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs.exe not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a56e4bcc832fad633a3ca483799f