### PR TITLE
Introduce scheduler and driver framework

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -5,7 +5,7 @@ all: disk.img
 bootloader.bin: asm/bootloader.asm
 	@nasm -f bin $< -o $@
 	
-kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/terminal.o src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o src/window.o src/exec.o src/taskbar.o
+kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/terminal.o src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o src/window.o src/exec.o src/taskbar.o src/scheduler.o src/driver.o src/mem.o src/kernel_main.o
 	@nasm -f elf32 asm/kernel.asm -o kernel_asm.o
 	@nasm -f elf32 asm/ports.asm -o ports.o
 	@gcc $(CFLAGS) -c src/graphics.c -o src/graphics.o
@@ -20,10 +20,15 @@ kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboar
 	@gcc $(CFLAGS) -c src/window.c -o src/window.o
 	@gcc $(CFLAGS) -c src/exec.c -o src/exec.o
 	@gcc $(CFLAGS) -c src/taskbar.c -o src/taskbar.o
+	@gcc $(CFLAGS) -c src/scheduler.c -o src/scheduler.o
+	@gcc $(CFLAGS) -c src/driver.c -o src/driver.o
+	@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
+	@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
 	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
-	    src/graphics.o src/screen.o src/keyboard.o src/terminal.o \
-            src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o \
-            src/window.o src/exec.o src/taskbar.o --oformat binary -o $@
+    src/graphics.o src/screen.o src/keyboard.o src/terminal.o \
+    src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o \
+    src/window.o src/exec.o src/taskbar.o src/scheduler.o src/driver.o \
+    src/mem.o src/kernel_main.o --oformat binary -o $@
 	
 disk.img: bootloader.bin kernel.bin
 	@cat bootloader.bin kernel.bin > $@

--- a/OptrixOS-Kernel/asm/kernel.asm
+++ b/OptrixOS-Kernel/asm/kernel.asm
@@ -1,20 +1,14 @@
 BITS 32
 
 extern graphics_set_framebuffer
-extern screen_init
-extern boot_logo
-extern desktop_init
-extern desktop_run
+extern kernel_main
 
 global start
 start:
     push ebx
     call graphics_set_framebuffer
     add esp, 4
-    call screen_init
-    call boot_logo
-    call desktop_init
-    call desktop_run
+    call kernel_main
 .halt:
     hlt
     jmp .halt

--- a/OptrixOS-Kernel/include/driver.h
+++ b/OptrixOS-Kernel/include/driver.h
@@ -1,0 +1,14 @@
+#ifndef DRIVER_H
+#define DRIVER_H
+
+typedef struct {
+    const char *name;
+    void (*init)(void);
+    void (*update)(void);
+} driver_t;
+
+void driver_register(driver_t *drv);
+void driver_init_all(void);
+void driver_update_all(void);
+
+#endif

--- a/OptrixOS-Kernel/include/mem.h
+++ b/OptrixOS-Kernel/include/mem.h
@@ -1,0 +1,8 @@
+#ifndef MEM_H
+#define MEM_H
+#include <stddef.h>
+
+void mem_init(unsigned char *base, size_t size);
+void* mem_alloc(size_t size);
+
+#endif

--- a/OptrixOS-Kernel/include/scheduler.h
+++ b/OptrixOS-Kernel/include/scheduler.h
@@ -1,0 +1,10 @@
+#ifndef SCHEDULER_H
+#define SCHEDULER_H
+
+typedef void (*task_func_t)(void *);
+
+void scheduler_init(void);
+int scheduler_add(task_func_t func, void *arg);
+void scheduler_run(void);
+
+#endif

--- a/OptrixOS-Kernel/src/driver.c
+++ b/OptrixOS-Kernel/src/driver.c
@@ -1,0 +1,23 @@
+#include "driver.h"
+
+#define MAX_DRIVERS 16
+
+static driver_t *drivers[MAX_DRIVERS];
+static int driver_count = 0;
+
+void driver_register(driver_t *drv) {
+    if(driver_count < MAX_DRIVERS)
+        drivers[driver_count++] = drv;
+}
+
+void driver_init_all(void) {
+    for(int i=0;i<driver_count;i++)
+        if(drivers[i]->init)
+            drivers[i]->init();
+}
+
+void driver_update_all(void) {
+    for(int i=0;i<driver_count;i++)
+        if(drivers[i]->update)
+            drivers[i]->update();
+}

--- a/OptrixOS-Kernel/src/kernel_main.c
+++ b/OptrixOS-Kernel/src/kernel_main.c
@@ -1,0 +1,26 @@
+#include "screen.h"
+#include "boot_logo.h"
+#include "desktop.h"
+#include "scheduler.h"
+#include "driver.h"
+#include "mem.h"
+
+/* simple heap placed at 0x200000 for illustration */
+#define HEAP_BASE ((unsigned char*)0x200000)
+#define HEAP_SIZE (64*1024)
+
+static void desktop_task(void *arg) {
+    (void)arg;
+    desktop_init();
+    desktop_run();
+}
+
+void kernel_main(void) {
+    screen_init();
+    boot_logo();
+    mem_init(HEAP_BASE, HEAP_SIZE);
+    scheduler_init();
+    scheduler_add(desktop_task, 0);
+    driver_init_all();
+    scheduler_run();
+}

--- a/OptrixOS-Kernel/src/mem.c
+++ b/OptrixOS-Kernel/src/mem.c
@@ -1,0 +1,19 @@
+#include "mem.h"
+
+static unsigned char *heap_base = 0;
+static size_t heap_size = 0;
+static size_t heap_used = 0;
+
+void mem_init(unsigned char *base, size_t size) {
+    heap_base = base;
+    heap_size = size;
+    heap_used = 0;
+}
+
+void* mem_alloc(size_t size) {
+    if(!heap_base || heap_used + size > heap_size)
+        return 0;
+    void* ptr = heap_base + heap_used;
+    heap_used += size;
+    return ptr;
+}

--- a/OptrixOS-Kernel/src/scheduler.c
+++ b/OptrixOS-Kernel/src/scheduler.c
@@ -1,0 +1,31 @@
+#include "scheduler.h"
+
+#define MAX_TASKS 16
+
+typedef struct {
+    task_func_t func;
+    void *arg;
+} task_t;
+
+static task_t tasks[MAX_TASKS];
+static int task_count = 0;
+
+void scheduler_init(void) {
+    task_count = 0;
+}
+
+int scheduler_add(task_func_t func, void *arg) {
+    if(task_count >= MAX_TASKS)
+        return 0;
+    tasks[task_count].func = func;
+    tasks[task_count].arg = arg;
+    task_count++;
+    return 1;
+}
+
+void scheduler_run(void) {
+    for(int i = 0; i < task_count; i++) {
+        if(tasks[i].func)
+            tasks[i].func(tasks[i].arg);
+    }
+}


### PR DESCRIPTION
## Summary
- implement a small task scheduler and driver API
- add basic heap allocator and kernel main in C
- update boot assembly to call new kernel entry
- extend Makefile to build the new modules

## Testing
- `make -C OptrixOS-Kernel clean`
- `make -C OptrixOS-Kernel all`

------
https://chatgpt.com/codex/tasks/task_e_6850ab180c48832fa281584fe1797fd8