### PR TITLE
Add meminfo command and taskbar interaction

### DIFF
--- a/OptrixOS-Kernel/include/mem.h
+++ b/OptrixOS-Kernel/include/mem.h
@@ -4,5 +4,8 @@
 
 void mem_init(unsigned char *base, size_t size);
 void* mem_alloc(size_t size);
+size_t mem_total(void);
+size_t mem_used(void);
+size_t mem_free(void);
 
 #endif

--- a/OptrixOS-Kernel/include/taskbar.h
+++ b/OptrixOS-Kernel/include/taskbar.h
@@ -7,5 +7,6 @@ void taskbar_init(void);
 void taskbar_register(window_t *win);
 void taskbar_unregister(window_t *win);
 void taskbar_draw(void);
+void taskbar_handle_click(int x, int y);
 
 #endif

--- a/OptrixOS-Kernel/src/desktop.c
+++ b/OptrixOS-Kernel/src/desktop.c
@@ -108,6 +108,7 @@ void desktop_run(void) {
                     break;
                 }
             }
+            taskbar_handle_click(mx, my);
         } else {
             if(click_timer>0) click_timer++;
             if(click_timer>30){ click_timer=0; last_clicked=-1; }

--- a/OptrixOS-Kernel/src/mem.c
+++ b/OptrixOS-Kernel/src/mem.c
@@ -17,3 +17,7 @@ void* mem_alloc(size_t size) {
     heap_used += size;
     return ptr;
 }
+size_t mem_total(void) { return heap_size; }
+size_t mem_used(void) { return heap_used; }
+size_t mem_free(void) { return heap_size > heap_used ? heap_size - heap_used : 0; }
+

--- a/OptrixOS-Kernel/src/taskbar.c
+++ b/OptrixOS-Kernel/src/taskbar.c
@@ -49,3 +49,23 @@ void taskbar_draw(void) {
         }
     }
 }
+
+void taskbar_handle_click(int x, int y) {
+    const int bar_h = 16;
+    if(y < SCREEN_HEIGHT - bar_h)
+        return;
+    if(task_count == 0)
+        return;
+    int w = SCREEN_WIDTH / task_count;
+    int idx = x / w;
+    if(idx >= task_count)
+        return;
+    window_t *win = tasks[idx];
+    if(win->state == 2) {
+        win->state = 0;
+        window_draw(win);
+    } else {
+        win->state = 2;
+        window_draw(win);
+    }
+}

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -3,6 +3,7 @@
 #include "screen.h"
 #include "mouse.h"
 #include "fs.h"
+#include "mem.h"
 #include <stdint.h>
 #include <stddef.h>
 
@@ -250,6 +251,7 @@ static void cmd_help(void) {
     print("whoami     - display current user\n");
     print("hello      - greet the user\n");
     print("uptime     - show uptime counter\n");
+    print("meminfo    - show memory usage\n");
 }
 
 static void cmd_clear(void) {
@@ -340,6 +342,16 @@ static void cmd_uptime(void) {
     print("Uptime: ");
     print_int(uptime_counter);
     print(" ticks\n");
+}
+
+static void cmd_meminfo(void) {
+    print("Total: ");
+    print_int(mem_total());
+    print(" bytes, Used: ");
+    print_int(mem_used());
+    print(" bytes, Free: ");
+    print_int(mem_free());
+    print(" bytes\n");
 }
 
 #include "fs.h"
@@ -571,6 +583,8 @@ static void execute(const char* line) {
         cmd_hello();
     } else if(streq(line, "uptime")) {
         cmd_uptime();
+    } else if(streq(line, "meminfo")) {
+        cmd_meminfo();
     } else if(streq(line, "ls")) {
         cmd_dir();
     } else if(line[0]) {


### PR DESCRIPTION
## Summary
- expose heap usage helpers
- add a meminfo terminal command to show memory usage
- allow clicking taskbar entries to restore/minimize windows

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_6850b1cacea4832f8d0bfa6980a16ca4