### PR TITLE
Fix app launch and simplify execution

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -5,7 +5,7 @@ all: disk.img
 bootloader.bin: asm/bootloader.asm
 	@nasm -f bin $< -o $@
 	
-kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/terminal.o src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o src/window.o src/exec.o src/taskbar.o src/scheduler.o src/driver.o src/mem.o src/kernel_main.o
+kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/terminal.o src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o src/window.o src/exec.o src/taskbar.o src/driver.o src/mem.o src/kernel_main.o
 	@nasm -f elf32 asm/kernel.asm -o kernel_asm.o
 	@nasm -f elf32 asm/ports.asm -o ports.o
 	@gcc $(CFLAGS) -c src/graphics.c -o src/graphics.o
@@ -20,14 +20,13 @@ kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboar
 	@gcc $(CFLAGS) -c src/window.c -o src/window.o
 	@gcc $(CFLAGS) -c src/exec.c -o src/exec.o
 	@gcc $(CFLAGS) -c src/taskbar.c -o src/taskbar.o
-	@gcc $(CFLAGS) -c src/scheduler.c -o src/scheduler.o
 	@gcc $(CFLAGS) -c src/driver.c -o src/driver.o
 	@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
 	@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
 	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
     src/graphics.o src/screen.o src/keyboard.o src/terminal.o \
     src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o \
-    src/window.o src/exec.o src/taskbar.o src/scheduler.o src/driver.o \
+    src/window.o src/exec.o src/taskbar.o src/driver.o \
     src/mem.o src/kernel_main.o --oformat binary -o $@
 	
 disk.img: bootloader.bin kernel.bin

--- a/OptrixOS-Kernel/src/exec.c
+++ b/OptrixOS-Kernel/src/exec.c
@@ -2,7 +2,6 @@
 #include <stddef.h>
 #include "screen.h"
 #include "taskbar.h"
-#include "scheduler.h"
 #include "mem.h"
 
 #define MAX_EXECS 10
@@ -12,16 +11,6 @@ typedef struct {
     exec_func_t func;
 } exec_entry;
 
-typedef struct {
-    window_t win;
-    exec_func_t func;
-} exec_task_t;
-
-static void exec_task_func(void *arg) {
-    exec_task_t *t = (exec_task_t*)arg;
-    t->func(&t->win);
-    taskbar_unregister(&t->win);
-}
 
 static exec_entry table[MAX_EXECS];
 static int exec_count = 0;
@@ -44,18 +33,18 @@ void exec_register(const char* name, exec_func_t func) {
 }
 
 int exec_run(const char* name) {
-    for(int i=0;i<exec_count;i++) {
+    for(int i = 0; i < exec_count; i++) {
         if(streq(table[i].name, name)) {
-            exec_task_t *t = mem_alloc(sizeof(exec_task_t));
-            if(!t) return 0;
+            window_t *win = mem_alloc(sizeof(window_t));
+            if(!win) return 0;
             int w = 400, h = 250;
             int x = (SCREEN_WIDTH - w) / 2;
             int y = (SCREEN_HEIGHT - h) / 2;
-            window_init(&t->win, x, y, w, h, name, 0x07, 0x17);
-            window_draw(&t->win);
-            taskbar_register(&t->win);
-            t->func = table[i].func;
-            scheduler_add(exec_task_func, t);
+            window_init(win, x, y, w, h, name, 0x07, 0x17);
+            window_draw(win);
+            taskbar_register(win);
+            table[i].func(win);
+            taskbar_unregister(win);
             return 1;
         }
     }

--- a/OptrixOS-Kernel/src/kernel_main.c
+++ b/OptrixOS-Kernel/src/kernel_main.c
@@ -1,7 +1,6 @@
 #include "screen.h"
 #include "boot_logo.h"
 #include "desktop.h"
-#include "scheduler.h"
 #include "driver.h"
 #include "mem.h"
 
@@ -9,18 +8,11 @@
 #define HEAP_BASE ((unsigned char*)0x200000)
 #define HEAP_SIZE (64*1024)
 
-static void desktop_task(void *arg) {
-    (void)arg;
-    desktop_init();
-    desktop_run();
-}
-
 void kernel_main(void) {
     screen_init();
     boot_logo();
     mem_init(HEAP_BASE, HEAP_SIZE);
-    scheduler_init();
-    scheduler_add(desktop_task, 0);
     driver_init_all();
-    scheduler_run();
+    desktop_init();
+    desktop_run();
 }

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -607,6 +607,7 @@ void terminal_run(window_t *win) {
         if(!win->visible) break;
         if(buf[0])
             execute(buf);
+        terminal_recursive_update();
         uptime_counter++;
     }
 }

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -266,6 +266,8 @@ def cleanup():
 def main():
     print("Collecting all project source files...")
     asm_files, c_files, h_files = collect_source_files(KERNEL_PROJECT_ROOT)
+    # Exclude the old scheduler from builds
+    c_files = [f for f in c_files if not f.endswith('scheduler.c')]
     print(f"Found {len(asm_files)} asm, {len(c_files)} c, {len(h_files)} h files.")
     boot_bin, kernel_bin = build_kernel(asm_files, c_files, out_bin=KERNEL_BIN)
     make_dynamic_img(boot_bin, kernel_bin, DISK_IMG)


### PR DESCRIPTION
## Summary
- open apps synchronously instead of using the unfinished scheduler
- update the terminal window every command
- drop scheduler references from the Makefile and build script
- start the desktop directly from the kernel

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs.exe not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850b56bfd38832f9097b871c4f805d6