### PR TITLE
Fix window redraw and bump resolution

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -13,9 +13,9 @@ start:
     mov ss, ax
     mov sp, 0x7C00
 
-    ; Get VESA mode information for 0x103
+    ; Get VESA mode information for 0x105
     mov ax, 0x4F01
-    mov cx, 0x103
+    mov cx, 0x105
     mov di, mode_info
     int 0x10
     ; Save linear framebuffer address
@@ -23,9 +23,9 @@ start:
     mov eax, [si + 0x28]
     mov [fb_addr], eax
 
-    ; Set VESA graphics mode 0x4103 (800x600 256 colors, linear FB)
+    ; Set VESA graphics mode 0x4105 (1024x768 256 colors, linear FB)
     mov ax, 0x4F02
-    mov bx, 0x4103
+    mov bx, 0x4105
     int 0x10
 
     ; load kernel (assumes kernel starts at second sector)

--- a/OptrixOS-Kernel/include/desktop.h
+++ b/OptrixOS-Kernel/include/desktop.h
@@ -3,5 +3,6 @@
 
 void desktop_init(void);
 void desktop_run(void);
+void desktop_redraw_region(int x, int y, int w, int h);
 
 #endif

--- a/OptrixOS-Kernel/include/graphics.h
+++ b/OptrixOS-Kernel/include/graphics.h
@@ -6,4 +6,5 @@ uint8_t get_pixel(int x, int y);
 void draw_rect(int x, int y, int w, int h, uint8_t color);
 void draw_rounded_rect(int x, int y, int w, int h, int r, uint8_t color);
 void graphics_set_framebuffer(uint32_t addr);
+void graphics_flush(int x, int y, int w, int h);
 #endif

--- a/OptrixOS-Kernel/include/screen.h
+++ b/OptrixOS-Kernel/include/screen.h
@@ -3,8 +3,8 @@
 
 #include <stdint.h>
 
-#define SCREEN_WIDTH 800
-#define SCREEN_HEIGHT 600
+#define SCREEN_WIDTH 1024
+#define SCREEN_HEIGHT 768
 #define BASE_CHAR_SIZE 8
 extern int CHAR_WIDTH;
 extern int CHAR_HEIGHT;

--- a/OptrixOS-Kernel/src/graphics.c
+++ b/OptrixOS-Kernel/src/graphics.c
@@ -1,24 +1,42 @@
 #include "graphics.h"
+#include "screen.h"
 #include <stdint.h>
 
-#define WIDTH 800
-#define HEIGHT 600
 static volatile uint8_t *VGA = (uint8_t *)0xA0000;
+static uint8_t backbuffer[SCREEN_WIDTH * SCREEN_HEIGHT];
+
+static void flush_rect(int x, int y, int w, int h) {
+    if(x < 0) { w += x; x = 0; }
+    if(y < 0) { h += y; y = 0; }
+    if(x + w > SCREEN_WIDTH) w = SCREEN_WIDTH - x;
+    if(y + h > SCREEN_HEIGHT) h = SCREEN_HEIGHT - y;
+    for(int j = 0; j < h; j++) {
+        for(int i = 0; i < w; i++) {
+            VGA[(y+j)*SCREEN_WIDTH + (x+i)] =
+                backbuffer[(y+j)*SCREEN_WIDTH + (x+i)];
+        }
+    }
+}
+
+void graphics_flush(int x, int y, int w, int h) {
+    flush_rect(x, y, w, h);
+}
 
 void graphics_set_framebuffer(uint32_t addr) {
     VGA = (volatile uint8_t *)addr;
+    flush_rect(0, 0, SCREEN_WIDTH, SCREEN_HEIGHT);
 }
 
 void put_pixel(int x, int y, uint8_t color) {
-    if (x < 0 || x >= WIDTH || y < 0 || y >= HEIGHT)
+    if (x < 0 || x >= SCREEN_WIDTH || y < 0 || y >= SCREEN_HEIGHT)
         return;
-    VGA[y * WIDTH + x] = color;
+    backbuffer[y * SCREEN_WIDTH + x] = color;
 }
 
 uint8_t get_pixel(int x, int y) {
-    if (x < 0 || x >= WIDTH || y < 0 || y >= HEIGHT)
+    if (x < 0 || x >= SCREEN_WIDTH || y < 0 || y >= SCREEN_HEIGHT)
         return 0;
-    return VGA[y * WIDTH + x];
+    return backbuffer[y * SCREEN_WIDTH + x];
 }
 
 void draw_rect(int x, int y, int w, int h, uint8_t color) {
@@ -27,6 +45,7 @@ void draw_rect(int x, int y, int w, int h, uint8_t color) {
             put_pixel(x + i, y + j, color);
         }
     }
+    flush_rect(x, y, w, h);
 }
 
 void draw_rounded_rect(int x, int y, int w, int h, int r, uint8_t color) {
@@ -46,4 +65,5 @@ void draw_rounded_rect(int x, int y, int w, int h, int r, uint8_t color) {
             }
         }
     }
+    flush_rect(x, y, w, h);
 }

--- a/OptrixOS-Kernel/src/mouse.c
+++ b/OptrixOS-Kernel/src/mouse.c
@@ -21,12 +21,14 @@ void mouse_draw(uint8_t bg_color) {
         for(int dy=0; dy<4; dy++)
             for(int dx=0; dx<4; dx++)
                 put_pixel(prev_x-2+dx, prev_y-2+dy, saved_bg[dy][dx]);
+        graphics_flush(prev_x-2, prev_y-2, 4, 4);
     }
     if(cursor_visible) {
         for(int dy=0; dy<4; dy++)
             for(int dx=0; dx<4; dx++)
                 saved_bg[dy][dx] = get_pixel(mx-2+dx, my-2+dy);
         draw_rect(mx-2, my-2, 4, 4, 0x0F);
+        graphics_flush(mx-2, my-2, 4, 4);
         prev_x = mx; prev_y = my;
     } else {
         prev_x = prev_y = -1;

--- a/OptrixOS-Kernel/src/screen.c
+++ b/OptrixOS-Kernel/src/screen.c
@@ -62,6 +62,7 @@ void screen_put_char(int col, int row, char c, uint8_t color) {
                 put_pixel(x+cx, y+cy, BACKGROUND_COLOR);
         }
     }
+    graphics_flush(x, y, CHAR_WIDTH, CHAR_HEIGHT);
 }
 
 void screen_put_char_offset(int col, int row, char c, uint8_t color,
@@ -79,6 +80,7 @@ void screen_put_char_offset(int col, int row, char c, uint8_t color,
                 put_pixel(x+cx, y+cy, BACKGROUND_COLOR);
         }
     }
+    graphics_flush(x, y, CHAR_WIDTH, CHAR_HEIGHT);
 }
 
 void screen_init(void) {

--- a/OptrixOS-Kernel/src/window.c
+++ b/OptrixOS-Kernel/src/window.c
@@ -4,6 +4,7 @@
 #include "mouse.h"
 #include "taskbar.h"
 #include "terminal.h"
+#include "desktop.h"
 
 static int drag = 0;
 static int resize = 0;
@@ -45,7 +46,8 @@ void window_draw(window_t* win) {
 
     /* clear previous location if window moved */
     if(x != win->px || y != win->py || w != win->pw || h != win->ph) {
-        draw_rect(win->px, win->py, win->pw, win->ph, win->bg_color);
+        if(win->px != -1 && win->py != -1)
+            desktop_redraw_region(win->px, win->py, win->pw, win->ph);
         win->px = x; win->py = y; win->pw = w; win->ph = h;
     } else {
         /* nothing changed - avoid redraw flicker */

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ behaviour of the historic `fsboot` loader. When executed it:
 - Loads the kernel from the disk image into memory at `0x1000`.
 - Initializes a simple GDT and switches the CPU to 32-bit protected mode.
 - Jumps to the kernel entry point.
-- Uses the VESA linear framebuffer so the full 800x600 screen is accessible.
+- Uses the VESA linear framebuffer so the full 1024x768 screen is accessible.
 - Bootloader prints progress messages while loading the kernel.
 - Displays a simple spinning logo for a few seconds before launching the
   terminal.
@@ -50,7 +50,7 @@ qemu-system-x86_64 -hda disk.img
 
 After boot a login prompt asks for the admin password (`admin1`). Once logged
 in a simple text terminal is available. The screen now runs in a
-high‑resolution 800x600 graphics mode with characters rendered at a 21‑pixel
+high‑resolution 1024x768 graphics mode with characters rendered at a 21‑pixel
 size. A title bar with a box-drawing border is drawn using VGA graphics
 characters. The background is white with black text while the cursor is
 rendered in bright yellow. The hardware text mode cursor is disabled so only the


### PR DESCRIPTION
## Summary
- redraw desktop regions when moving windows to avoid ghosting
- track a backbuffer and flush updated regions
- add partial screen redraw helpers
- bump graphics mode to 1024x768
- document new resolution

## Testing
- `make -C OptrixOS-Kernel clean all`

------
https://chatgpt.com/codex/tasks/task_e_6850b79b223c832fb73d3b224ee414d5