### PR TITLE
Simplify window styling

### DIFF
--- a/OptrixOS-Kernel/src/desktop.c
+++ b/OptrixOS-Kernel/src/desktop.c
@@ -8,13 +8,12 @@
 #include "fs.h"
 #include "taskbar.h"
 
-#define DESKTOP_BG_COLOR 0x17
+#define DESKTOP_BG_COLOR 0x12
 
 static void draw_wallpaper(void) {
     for(int y=0; y<SCREEN_HEIGHT; y++) {
         for(int x=0; x<SCREEN_WIDTH; x++) {
-            uint8_t c = ((x/8) ^ (y/8)) & 0x0F;
-            put_pixel(x, y, c | 0x10);
+            put_pixel(x, y, DESKTOP_BG_COLOR);
         }
     }
 }
@@ -26,8 +25,7 @@ static void draw_wallpaper_region(int x, int y, int w, int h) {
     if(y + h > SCREEN_HEIGHT) h = SCREEN_HEIGHT - y;
     for(int yy = y; yy < y + h; yy++) {
         for(int xx = x; xx < x + w; xx++) {
-            uint8_t c = ((xx/8) ^ (yy/8)) & 0x0F;
-            put_pixel(xx, yy, c | 0x10);
+            put_pixel(xx, yy, DESKTOP_BG_COLOR);
         }
     }
 }

--- a/OptrixOS-Kernel/src/mouse.c
+++ b/OptrixOS-Kernel/src/mouse.c
@@ -10,7 +10,21 @@ static int clicked = 0;
 static int mouse_present = 0;
 static int cursor_visible = 1;
 static int prev_x = -1, prev_y = -1;
-static uint8_t saved_bg[4][4];
+#define CURSOR_W 6
+#define CURSOR_H 9
+static uint8_t saved_bg[CURSOR_H][CURSOR_W];
+
+static const uint8_t cursor_shape[CURSOR_H] = {
+    0b100000,
+    0b110000,
+    0b111000,
+    0b111100,
+    0b111110,
+    0b111111,
+    0b011110,
+    0b001100,
+    0b000000
+};
 
 void mouse_set_visible(int vis) { cursor_visible = vis; }
 int mouse_get_visible(void) { return cursor_visible; }
@@ -18,15 +32,20 @@ int mouse_get_visible(void) { return cursor_visible; }
 void mouse_draw(uint8_t bg_color) {
     (void)bg_color;
     if(prev_x != -1 && prev_y != -1 && cursor_visible) {
-        for(int dy=0; dy<4; dy++)
-            for(int dx=0; dx<4; dx++)
-                put_pixel(prev_x-2+dx, prev_y-2+dy, saved_bg[dy][dx]);
+        for(int dy=0; dy<CURSOR_H; dy++)
+            for(int dx=0; dx<CURSOR_W; dx++)
+                put_pixel(prev_x+dx, prev_y+dy, saved_bg[dy][dx]);
     }
     if(cursor_visible) {
-        for(int dy=0; dy<4; dy++)
-            for(int dx=0; dx<4; dx++)
-                saved_bg[dy][dx] = get_pixel(mx-2+dx, my-2+dy);
-        draw_rect(mx-2, my-2, 4, 4, 0x0F);
+        for(int dy=0; dy<CURSOR_H; dy++)
+            for(int dx=0; dx<CURSOR_W; dx++)
+                saved_bg[dy][dx] = get_pixel(mx+dx, my+dy);
+        for(int dy=0; dy<CURSOR_H; dy++) {
+            for(int dx=0; dx<CURSOR_W; dx++) {
+                if(cursor_shape[dy] & (1 << (CURSOR_W-1-dx)))
+                    put_pixel(mx+dx, my+dy, 0x0F);
+            }
+        }
         prev_x = mx; prev_y = my;
     } else {
         prev_x = prev_y = -1;

--- a/OptrixOS-Kernel/src/taskbar.c
+++ b/OptrixOS-Kernel/src/taskbar.c
@@ -3,7 +3,7 @@
 #include "screen.h"
 
 #define MAX_TASKS 10
-#define TASKBAR_COLOR 0x01
+#define TASKBAR_COLOR 0x18
 
 static window_t *tasks[MAX_TASKS];
 static int task_count = 0;

--- a/OptrixOS-Kernel/src/window.c
+++ b/OptrixOS-Kernel/src/window.c
@@ -61,15 +61,7 @@ void window_draw(window_t* win) {
     draw_rect(x, y+14, w, h-14, win->color);
     /* top bar with rounded corners */
     draw_rounded_rect(x, y, w, 14, 6, 0x01);
-    /* border */
-    draw_rounded_rect(x, y, w, h, 6, 0x08);
     if(show_bar) {
-        if(win->title) {
-            const char *t = win->title;
-            for(int i=0; t[i] && i<20; i++)
-                screen_put_char((x+4-OFFSET_X)/CHAR_WIDTH + i,
-                                (y+3-OFFSET_Y)/CHAR_HEIGHT, t[i], 0x0F);
-        }
         draw_buttons(x+w, y);
     }
 }


### PR DESCRIPTION
## Summary
- give the desktop a calmer blue wallpaper
- modernize the mouse cursor drawing
- remove window titles and borders for a simpler look
- darken the taskbar color

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs missing)*

------
https://chatgpt.com/codex/tasks/task_e_6850bc5cb3e4832fb6414dbbff9c65a6