### PR TITLE
Remove terminal and taskbar

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -5,29 +5,24 @@ all: disk.img
 bootloader.bin: asm/bootloader.asm
 	@nasm -f bin $< -o $@
 	
-kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/terminal.o src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o src/window.o src/exec.o src/taskbar.o src/driver.o src/mem.o src/kernel_main.o
+kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o src/driver.o src/mem.o src/kernel_main.o
 	@nasm -f elf32 asm/kernel.asm -o kernel_asm.o
 	@nasm -f elf32 asm/ports.asm -o ports.o
 	@gcc $(CFLAGS) -c src/graphics.c -o src/graphics.o
 	@gcc $(CFLAGS) -c src/screen.c -o src/screen.o
 	@gcc $(CFLAGS) -c src/keyboard.c -o src/keyboard.o
-	@gcc $(CFLAGS) -c src/terminal.c -o src/terminal.o
 	@gcc $(CFLAGS) -c src/fs.c -o src/fs.o
 	@gcc $(CFLAGS) -c src/boot_logo.c -o src/boot_logo.o
 	@gcc $(CFLAGS) -c src/login.c -o src/login.o
 	@gcc $(CFLAGS) -c src/desktop.c -o src/desktop.o
 	@gcc $(CFLAGS) -c src/mouse.c -o src/mouse.o
-	@gcc $(CFLAGS) -c src/window.c -o src/window.o
-	@gcc $(CFLAGS) -c src/exec.c -o src/exec.o
-	@gcc $(CFLAGS) -c src/taskbar.c -o src/taskbar.o
 	@gcc $(CFLAGS) -c src/driver.c -o src/driver.o
 	@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
 	@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
-	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
-    src/graphics.o src/screen.o src/keyboard.o src/terminal.o \
+    @ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
+    src/graphics.o src/screen.o src/keyboard.o \
     src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o \
-    src/window.o src/exec.o src/taskbar.o src/driver.o \
-    src/mem.o src/kernel_main.o --oformat binary -o $@
+    src/driver.o src/mem.o src/kernel_main.o --oformat binary -o $@
 	
 disk.img: bootloader.bin kernel.bin
 	@cat bootloader.bin kernel.bin > $@

--- a/OptrixOS-Kernel/src/desktop.c
+++ b/OptrixOS-Kernel/src/desktop.c
@@ -2,165 +2,59 @@
 #include "screen.h"
 #include "graphics.h"
 #include "mouse.h"
-#include "terminal.h"
-#include "window.h"
-#include "exec.h"
 #include "fs.h"
-#include "taskbar.h"
 
-#define DESKTOP_BG_COLOR 0x12
+#define DESKTOP_BG_COLOR 0x17
 
 static void draw_wallpaper(void) {
-    for(int y=0; y<SCREEN_HEIGHT; y++) {
-        for(int x=0; x<SCREEN_WIDTH; x++) {
+    for(int y=0; y<SCREEN_HEIGHT; y++)
+        for(int x=0; x<SCREEN_WIDTH; x++)
             put_pixel(x, y, DESKTOP_BG_COLOR);
-        }
-    }
 }
 
-static void draw_wallpaper_region(int x, int y, int w, int h) {
-    if(x < 0) { w += x; x = 0; }
-    if(y < 0) { h += y; y = 0; }
-    if(x + w > SCREEN_WIDTH)  w = SCREEN_WIDTH - x;
-    if(y + h > SCREEN_HEIGHT) h = SCREEN_HEIGHT - y;
-    for(int yy = y; yy < y + h; yy++) {
-        for(int xx = x; xx < x + w; xx++) {
-            put_pixel(xx, yy, DESKTOP_BG_COLOR);
-        }
-    }
-}
-#define MAX_ICONS 20
+static void draw_demo_window(void) {
+    const int x = 68;
+    const int y = 48;
+    const int w = 512;
+    const int h = 336;
+    const uint8_t hl = 0x0F; /* highlight */
+    const uint8_t sh = 0x08; /* shadow */
+    const uint8_t mid = 0x07; /* medium grey */
 
-typedef struct { int x; int y; fs_entry* entry; } icon_t;
+    /* outer frame */
+    draw_rect(x, y, w, 2, hl);
+    draw_rect(x, y, 2, h, hl);
+    draw_rect(x, y+h-2, w, 2, sh);
+    draw_rect(x+w-2, y, 2, h, sh);
 
-static icon_t icons[MAX_ICONS];
-static int icon_count = 0;
-static int click_timer = 0;
-static int last_clicked = -1;
-static int fs_ready = 0;
+    /* inner ridge */
+    draw_rect(x+2, y+2, w-4, 1, mid);
+    draw_rect(x+2, y+2, 1, h-4, mid);
+    draw_rect(x+3, y+h-3, w-4, 1, mid);
+    draw_rect(x+w-3, y+2, 1, h-4, mid);
 
-static void terminal_exec(window_t *win) {
-    terminal_set_window(win);
-    terminal_init();
-    terminal_run(win);
-}
-
-static void draw_icons(void) {
-    const int spacing = 40;
-    int x = 50;
-    int y = 50;
-    for(int i=0; i<icon_count; i++) {
-        icons[i].x = x;
-        icons[i].y = y;
-        const char *name = icons[i].entry->name;
-        uint8_t col = 0x07;
-        int len = 0;
-        while(name[len]) len++;
-        if(len > 4 && name[len-4]=='.' && name[len-3]=='o' &&
-           name[len-2]=='p' && name[len-1]=='t')
-            col = 0x03; /* OPT executable */
-        draw_rect(x, y, 32, 32, col);
-        char c = name[0];
-        screen_put_char((x+12-OFFSET_X)/CHAR_WIDTH,
-                       (y+12-OFFSET_Y)/CHAR_HEIGHT, c, 0x0F);
-        x += spacing;
-        if(x + 32 > SCREEN_WIDTH - 50) { x = 50; y += spacing; }
-    }
-}
-
-static void draw_icon(int idx) {
-    if(idx < 0 || idx >= icon_count) return;
-    const char *name = icons[idx].entry->name;
-    uint8_t col = 0x07;
-    int len = 0;
-    while(name[len]) len++;
-    if(len > 4 && name[len-4]=='.' && name[len-3]=='o' &&
-       name[len-2]=='p' && name[len-1]=='t')
-        col = 0x03;
-    draw_rect(icons[idx].x, icons[idx].y, 32, 32, col);
-    char c = name[0];
-    screen_put_char((icons[idx].x+12-OFFSET_X)/CHAR_WIDTH,
-                   (icons[idx].y+12-OFFSET_Y)/CHAR_HEIGHT, c, 0x0F);
-}
-
-static int in_icon(int idx, int x, int y) {
-    return (x >= icons[idx].x && x < icons[idx].x+32 &&
-            y >= icons[idx].y && y < icons[idx].y+32);
-}
-
-void desktop_redraw_region(int x, int y, int w, int h) {
-    draw_wallpaper_region(x, y, w, h);
-    for(int i=0; i<icon_count; i++) {
-        if(icons[i].x + 32 > x && icons[i].x < x + w &&
-           icons[i].y + 32 > y && icons[i].y < y + h) {
-            draw_icon(i);
-        }
-    }
-    if(y + h > SCREEN_HEIGHT - 16) /* refresh taskbar if needed */
-        taskbar_draw();
-}
-
-static void refresh_icons(void) {
-    fs_entry* desk = fs_find_subdir(fs_get_root(), "desktop");
-    if(!desk) { icon_count = 0; return; }
-    if(desk->child_count != icon_count) {
-        icon_count = 0;
-        for(int i=0; i<desk->child_count && i<MAX_ICONS; i++)
-            icons[icon_count++].entry = &desk->children[i];
-        draw_wallpaper();
-        draw_icons();
-    }
+    /* client area */
+    draw_rect(x+3, y+3, w-6, h-6, mid);
 }
 
 void desktop_init(void) {
-    if(!fs_ready) { fs_init(); fs_ready = 1; }
+    fs_init();
     draw_wallpaper();
-    fs_entry* root = fs_get_root();
-    fs_entry* desk = fs_find_subdir(root, "desktop");
-    icon_count = 0;
-    if(desk) {
-        for(int i=0; i<desk->child_count && i<MAX_ICONS; i++) {
-            icons[icon_count++].entry = &desk->children[i];
-        }
-    }
-    draw_icons();
-    exec_init();
-    exec_register("terminal.opt", terminal_exec);
-    taskbar_init();
+    draw_demo_window();
 }
 
 void desktop_run(void) {
     mouse_init();
     mouse_set_visible(1);
-    if(!mouse_is_present())
-        ; /* fallback will use keyboard input */
     mouse_draw(DESKTOP_BG_COLOR);
     while(1) {
         mouse_update();
-        refresh_icons();
-        taskbar_draw();
-        int mx = mouse_get_x();
-        int my = mouse_get_y();
-
-        if(mouse_clicked()) {
-            for(int i=0;i<icon_count;i++) {
-                if(in_icon(i,mx,my)) {
-                    if(click_timer>0 && last_clicked==i && click_timer<20) {
-                        exec_run(icons[i].entry->name);
-                        desktop_init();
-                    } else {
-                        last_clicked=i;
-                        click_timer=1;
-                    }
-                    break;
-                }
-            }
-            taskbar_handle_click(mx, my);
-        } else {
-            if(click_timer>0) click_timer++;
-            if(click_timer>30){ click_timer=0; last_clicked=-1; }
-        }
-
         mouse_draw(DESKTOP_BG_COLOR);
     }
+}
+
+void desktop_redraw_region(int x, int y, int w, int h) {
+    (void)x; (void)y; (void)w; (void)h;
+    draw_wallpaper();
+    draw_demo_window();
 }

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -60,9 +60,6 @@ void fs_init(void) {
     fs_entry readme = {"readme.txt", 0, &root_dir, NULL, 0, "Welcome to OptrixOS"};
     root_entries[root_count++] = readme;
 
-    /* /desktop/terminal.opt executable */
-    fs_entry term = {"terminal.opt", 0, desktop_ptr, NULL, 0, ""};
-    desktop_entries[desktop_count++] = term;
     desktop_ptr->child_count = desktop_count;
 
     root_dir.child_count = root_count;

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -268,6 +268,10 @@ def main():
     asm_files, c_files, h_files = collect_source_files(KERNEL_PROJECT_ROOT)
     # Exclude the old scheduler from builds
     c_files = [f for f in c_files if not f.endswith('scheduler.c')]
+    c_files = [f for f in c_files if not f.endswith('terminal.c')]
+    c_files = [f for f in c_files if not f.endswith('exec.c')]
+    c_files = [f for f in c_files if not f.endswith('taskbar.c')]
+    c_files = [f for f in c_files if not f.endswith('window.c')]
     print(f"Found {len(asm_files)} asm, {len(c_files)} c, {len(h_files)} h files.")
     boot_bin, kernel_bin = build_kernel(asm_files, c_files, out_bin=KERNEL_BIN)
     make_dynamic_img(boot_bin, kernel_bin, DISK_IMG)


### PR DESCRIPTION
## Summary
- strip out taskbar, executable support and terminal
- display a single demo window on a grey desktop
- trim build scripts and Makefile to exclude removed sources

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs.exe not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c2f93d60832fa2151ea56400a69a