### PR TITLE
Add Windows 3.1 UI mockup

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ script outputs `disk.img` which can be run with:
 qemu-system-x86_64 -hda disk.img
 ```
 
+## Windows 3.1 style desktop
+
+The repository includes an SVG mockup of a Windows 3.1 era Program Manager
+environment. It demonstrates the classic 3D widgets and menu bar design.
+
+![Program Manager mockup](windows31_program_manager.svg)
+
 ## Built-in terminal
 
 After boot a login prompt asks for the admin password (`admin1`). Once logged

--- a/windows31_program_manager.svg
+++ b/windows31_program_manager.svg
@@ -1,0 +1,95 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480">
+  <!-- desktop background -->
+  <rect x="0" y="0" width="640" height="480" fill="#c0c7c8" />
+
+  <!-- Program Manager window outer shadow -->
+  <rect x="68" y="48" width="512" height="336" fill="#c0c0c0" stroke="#808080" stroke-width="2" />
+  <!-- top and left highlight -->
+  <line x1="68" y1="48" x2="580" y2="48" stroke="#ffffff" stroke-width="2" />
+  <line x1="68" y1="48" x2="68" y2="384" stroke="#ffffff" stroke-width="2" />
+
+  <!-- inner gray ridge -->
+  <rect x="70" y="50" width="508" height="332" fill="none" stroke="#c0c0c0" stroke-width="1" />
+
+  <!-- title bar -->
+  <rect x="71" y="51" width="506" height="18" fill="#a0a0a0" />
+  <!-- Program Manager icon -->
+  <rect x="77" y="55" width="13" height="13" fill="#ff0000" />
+  <rect x="83" y="55" width="7" height="6" fill="#00ff00" />
+  <rect x="77" y="61" width="6" height="7" fill="#0000ff" />
+  <rect x="86" y="61" width="4" height="7" fill="#ffff00" />
+  <text x="324" y="64" font-size="10" font-family="sans-serif" text-anchor="middle" fill="#000000">Program Manager</text>
+  <!-- control buttons -->
+  <rect x="542" y="54" width="15" height="13" fill="#a0a0a0" stroke="#808080" stroke-width="1" />
+  <line x1="545" y1="63" x2="555" y2="63" stroke="#000000" stroke-width="2" />
+  <rect x="560" y="54" width="15" height="13" fill="#a0a0a0" stroke="#808080" stroke-width="1" />
+  <rect x="564" y="58" width="7" height="7" fill="#000000" />
+
+  <!-- menu bar -->
+  <rect x="71" y="69" width="506" height="18" fill="#e0e0e0" />
+  <text x="90" y="82" font-size="8" font-family="sans-serif" fill="#000000">File</text>
+  <text x="146" y="82" font-size="8" font-family="sans-serif" fill="#000000">Options</text>
+  <text x="220" y="82" font-size="8" font-family="sans-serif" fill="#000000">Window</text>
+  <text x="304" y="82" font-size="8" font-family="sans-serif" fill="#000000">Help</text>
+
+  <!-- divider -->
+  <line x1="71" y1="87" x2="577" y2="87" stroke="#808080" stroke-width="1" />
+
+  <!-- main client area -->
+  <rect x="71" y="88" width="506" height="288" fill="#c0c0c0" />
+
+  <!-- about dialog -->
+  <rect x="182" y="156" width="316" height="162" fill="#ffffff" stroke="#ffffff" stroke-width="2" />
+  <rect x="182" y="156" width="316" height="162" fill="none" stroke="#808080" stroke-width="2" />
+  <!-- dialog title bar -->
+  <rect x="184" y="160" width="312" height="8" fill="#0000a0" />
+  <line x1="184" y1="160" x2="496" y2="160" stroke="#4a4aff" stroke-width="1" />
+  <!-- Windows logo -->
+  <rect x="310" y="168" width="32" height="32" fill="#ff0000" />
+  <rect x="326" y="168" width="16" height="16" fill="#00ff00" />
+  <rect x="310" y="184" width="16" height="16" fill="#0000ff" />
+  <rect x="326" y="184" width="16" height="16" fill="#ffff00" />
+  <!-- dialog text -->
+  <text x="340" y="208" font-size="8" font-family="sans-serif" text-anchor="middle" fill="#000000">386 Enhanced Mode Windows Version 3.10</text>
+  <text x="340" y="224" font-size="8" font-family="sans-serif" text-anchor="middle" fill="#000000">Copyright © 1991, Microsoft Corp.</text>
+  <!-- OK button -->
+  <rect x="310" y="246" width="60" height="18" fill="#c0c0c0" stroke="#ffffff" stroke-width="3" />
+  <rect x="310" y="246" width="60" height="18" fill="none" stroke="#808080" stroke-width="1" />
+  <text x="340" y="259" font-size="10" font-family="sans-serif" text-anchor="middle" fill="#000000">OK</text>
+
+  <!-- program group icons -->
+  <!-- Accessories icon -->
+  <rect x="120" y="342" width="48" height="48" fill="#ffffff" stroke="#000000" stroke-width="1" />
+  <text x="144" y="400" font-size="8" font-family="sans-serif" text-anchor="middle">Accessories</text>
+  <!-- Games icon -->
+  <rect x="200" y="342" width="48" height="48" fill="#ffffff" stroke="#000000" stroke-width="1" />
+  <text x="224" y="400" font-size="8" font-family="sans-serif" text-anchor="middle">Games</text>
+  <!-- StartUp icon -->
+  <rect x="280" y="342" width="48" height="48" fill="#ffffff" stroke="#000000" stroke-width="1" />
+  <text x="304" y="400" font-size="8" font-family="sans-serif" text-anchor="middle">StartUp</text>
+  <!-- Applications icon -->
+  <rect x="360" y="342" width="48" height="48" fill="#ffffff" stroke="#000000" stroke-width="1" />
+  <text x="384" y="400" font-size="8" font-family="sans-serif" text-anchor="middle">Applications</text>
+  <!-- Main icon -->
+  <rect x="440" y="342" width="48" height="48" fill="#ffffff" stroke="#000000" stroke-width="1" />
+  <text x="464" y="400" font-size="8" font-family="sans-serif" text-anchor="middle">Main</text>
+  <!-- Office icon -->
+  <rect x="520" y="342" width="48" height="48" fill="#ffffff" stroke="#000000" stroke-width="1" />
+  <text x="544" y="400" font-size="8" font-family="sans-serif" text-anchor="middle">Office</text>
+
+  <!-- Blank application window -->
+  <rect x="20" y="20" width="230" height="180" fill="#c0c0c0" stroke="#808080" stroke-width="2" />
+  <line x1="20" y1="20" x2="250" y2="20" stroke="#ffffff" stroke-width="2" />
+  <line x1="20" y1="20" x2="20" y2="200" stroke="#ffffff" stroke-width="2" />
+  <rect x="22" y="22" width="226" height="176" fill="none" stroke="#c0c0c0" stroke-width="1" />
+  <!-- blank window title bar -->
+  <rect x="23" y="23" width="224" height="18" fill="#a0a0a0" />
+  <!-- blank window controls -->
+  <rect x="212" y="26" width="15" height="13" fill="#a0a0a0" stroke="#808080" stroke-width="1" />
+  <line x1="215" y1="35" x2="225" y2="35" stroke="#000000" stroke-width="2" />
+  <rect x="229" y="26" width="15" height="13" fill="#a0a0a0" stroke="#808080" stroke-width="1" />
+  <rect x="233" y="30" width="7" height="7" fill="#000000" />
+  <text x="135" y="36" font-size="10" font-family="sans-serif" text-anchor="middle" fill="#000000">Blank</text>
+  <!-- blank client area -->
+  <rect x="23" y="41" width="224" height="158" fill="#c0c0c0" />
+</svg>


### PR DESCRIPTION
## Summary
- create a Windows 3.1 style Program Manager mockup
- include a blank application window using the same UI style

## Testing
- `python3 setup_bootloader.py` *(fails: `mkisofs.exe not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850c4967144832fa2246e34a32c328b