### PR TITLE
Add basic SVG support and expand file storage

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -1,11 +1,11 @@
-CFLAGS=-ffreestanding -fno-pie -fno-pic -m32 -Iinclude
+			CFLAGS=-ffreestanding -fno-pie -fno-pic -m32 -Iinclude
 	
 all: disk.img
 	
 bootloader.bin: asm/bootloader.asm
 	@nasm -f bin $< -o $@
 	
-kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o src/driver.o src/mem.o src/kernel_main.o
+kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o src/driver.o src/mem.o src/svg.o src/windows31_svg.o src/kernel_main.o
 	@nasm -f elf32 asm/kernel.asm -o kernel_asm.o
 	@nasm -f elf32 asm/ports.asm -o ports.o
 	@gcc $(CFLAGS) -c src/graphics.c -o src/graphics.o
@@ -18,11 +18,13 @@ kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboar
 	@gcc $(CFLAGS) -c src/mouse.c -o src/mouse.o
 	@gcc $(CFLAGS) -c src/driver.c -o src/driver.o
 	@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
+	@gcc $(CFLAGS) -c src/svg.c -o src/svg.o
+	@gcc $(CFLAGS) -c src/windows31_svg.c -o src/windows31_svg.o
 	@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
-    @ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
-    src/graphics.o src/screen.o src/keyboard.o \
-    src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o \
-    src/driver.o src/mem.o src/kernel_main.o --oformat binary -o $@
+	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
+src/graphics.o src/screen.o src/keyboard.o \
+src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o \
+src/driver.o src/mem.o src/svg.o src/windows31_svg.o src/kernel_main.o --oformat binary -o $@
 	
 disk.img: bootloader.bin kernel.bin
 	@cat bootloader.bin kernel.bin > $@

--- a/OptrixOS-Kernel/include/fs.h
+++ b/OptrixOS-Kernel/include/fs.h
@@ -1,13 +1,16 @@
 #ifndef FS_H
 #define FS_H
 
+/* Maximum file size in bytes. Increased to allow simple SVG assets. */
+#define FS_CONTENT_MAX 8192
+
 typedef struct fs_entry {
     char name[32];
     int is_dir;
     struct fs_entry* parent;
     struct fs_entry* children;
     int child_count;
-    char content[256];
+    char content[FS_CONTENT_MAX];
 } fs_entry;
 
 fs_entry* fs_find_entry(fs_entry* dir, const char* name);
@@ -15,7 +18,7 @@ fs_entry* fs_create_file(fs_entry* dir, const char* name);
 fs_entry* fs_create_dir(fs_entry* dir, const char* name);
 int fs_delete_entry(fs_entry* dir, const char* name);
 
-/* Write text content to a file entry. Text is truncated to 255 chars. */
+/* Write text content to a file entry. Text is truncated to FS_CONTENT_MAX-1 bytes. */
 void fs_write_file(fs_entry* file, const char* text);
 
 /* Read the content of a file entry. Returns empty string for directories */

--- a/OptrixOS-Kernel/include/mem.h
+++ b/OptrixOS-Kernel/include/mem.h
@@ -7,5 +7,7 @@ void* mem_alloc(size_t size);
 size_t mem_total(void);
 size_t mem_used(void);
 size_t mem_free(void);
+void *memcpy(void *dest, const void *src, size_t n);
+void *memset(void *dest, int c, size_t n);
 
 #endif

--- a/OptrixOS-Kernel/include/svg.h
+++ b/OptrixOS-Kernel/include/svg.h
@@ -1,0 +1,6 @@
+#ifndef SVG_H
+#define SVG_H
+
+void svg_render(const char *svg_text);
+
+#endif

--- a/OptrixOS-Kernel/include/windows31_svg.h
+++ b/OptrixOS-Kernel/include/windows31_svg.h
@@ -1,0 +1,6 @@
+#ifndef WINDOWS31_SVG_H
+#define WINDOWS31_SVG_H
+
+extern const char windows31_svg[];
+
+#endif

--- a/OptrixOS-Kernel/src/desktop.c
+++ b/OptrixOS-Kernel/src/desktop.c
@@ -3,6 +3,8 @@
 #include "graphics.h"
 #include "mouse.h"
 #include "fs.h"
+#include "svg.h"
+#include "windows31_svg.h"
 
 #define DESKTOP_BG_COLOR 0x17
 
@@ -40,7 +42,7 @@ static void draw_demo_window(void) {
 void desktop_init(void) {
     fs_init();
     draw_wallpaper();
-    draw_demo_window();
+    svg_render(windows31_svg);
 }
 
 void desktop_run(void) {
@@ -56,5 +58,5 @@ void desktop_run(void) {
 void desktop_redraw_region(int x, int y, int w, int h) {
     (void)x; (void)y; (void)w; (void)h;
     draw_wallpaper();
-    draw_demo_window();
+    svg_render(windows31_svg);
 }

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -1,4 +1,5 @@
 #include "fs.h"
+#include "windows31_svg.h"
 #include <stddef.h>
 
 static int streq(const char* a, const char* b) {
@@ -59,6 +60,11 @@ void fs_init(void) {
     /* simple readme */
     fs_entry readme = {"readme.txt", 0, &root_dir, NULL, 0, "Welcome to OptrixOS"};
     root_entries[root_count++] = readme;
+
+    /* embedded svg example */
+    fs_entry svg = {"demo.svg", 0, &root_dir, NULL, 0, ""};
+    fs_write_file(&svg, windows31_svg);
+    root_entries[root_count++] = svg;
 
     desktop_ptr->child_count = desktop_count;
 
@@ -127,7 +133,7 @@ int fs_delete_entry(fs_entry* dir, const char* name) {
 void fs_write_file(fs_entry* file, const char* text) {
     if(!file || file->is_dir) return;
     int k = 0;
-    while(text[k] && k < 255) {
+    while(text[k] && k < FS_CONTENT_MAX-1) {
         file->content[k] = text[k];
         k++;
     }

--- a/OptrixOS-Kernel/src/mem.c
+++ b/OptrixOS-Kernel/src/mem.c
@@ -21,3 +21,16 @@ size_t mem_total(void) { return heap_size; }
 size_t mem_used(void) { return heap_used; }
 size_t mem_free(void) { return heap_size > heap_used ? heap_size - heap_used : 0; }
 
+void *memcpy(void *dest, const void *src, size_t n) {
+    unsigned char *d = dest;
+    const unsigned char *s = src;
+    for(size_t i=0;i<n;i++) d[i]=s[i];
+    return dest;
+}
+
+void *memset(void *dest, int c, size_t n) {
+    unsigned char *d = dest;
+    for(size_t i=0;i<n;i++) d[i]=(unsigned char)c;
+    return dest;
+}
+

--- a/OptrixOS-Kernel/src/svg.c
+++ b/OptrixOS-Kernel/src/svg.c
@@ -1,0 +1,70 @@
+#include "svg.h"
+#include "graphics.h"
+#include <stdint.h>
+
+static int hex_digit(char c) {
+    if(c >= '0' && c <= '9') return c - '0';
+    if(c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if(c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return 0;
+}
+
+static uint8_t parse_color(const char* s) {
+    if(!s || s[0] != '#') return 0;
+    int r = hex_digit(s[1]) * 16 + hex_digit(s[2]);
+    int g = hex_digit(s[3]) * 16 + hex_digit(s[4]);
+    int b = hex_digit(s[5]) * 16 + hex_digit(s[6]);
+    return (uint8_t)((r + g + b) / 3); /* simple grayscale mapping */
+}
+
+static int parse_int(const char* s) {
+    int v = 0;
+    int i = 0;
+    while(s[i] >= '0' && s[i] <= '9') {
+        v = v * 10 + (s[i] - '0');
+        i++;
+    }
+    return v;
+}
+
+static const char* find_attr(const char* p, const char* name) {
+    int i = 0;
+    while(p[i] && p[i] != '>') {
+        int j = 0;
+        while(name[j] && p[i+j] == name[j]) j++;
+        if(name[j] == '\0' && p[i+j] == '=') {
+            const char* v = p + i + j + 1;
+            if(*v == '"' || *v == '\'') v++;
+            return v;
+        }
+        i++;
+    }
+    return 0;
+}
+
+static void parse_rect(const char* p) {
+    const char* val;
+    int x=0, y=0, w=0, h=0;
+    uint8_t color=0;
+    val = find_attr(p, "x"); if(val) x = parse_int(val);
+    val = find_attr(p, "y"); if(val) y = parse_int(val);
+    val = find_attr(p, "width"); if(val) w = parse_int(val);
+    val = find_attr(p, "height"); if(val) h = parse_int(val);
+    val = find_attr(p, "fill"); if(val) color = parse_color(val);
+    draw_rect(x, y, w, h, color);
+}
+
+void svg_render(const char* svg_text) {
+    const char* p = svg_text;
+    while(*p) {
+        if(*p == '<') {
+            p++;
+            if(p[0]=='r' && p[1]=='e' && p[2]=='c' && p[3]=='t') {
+                const char* attrs = p + 4;
+                while(*p && *p != '>') p++; /* move to end of tag */
+                parse_rect(attrs);
+            }
+        }
+        if(*p) p++;
+    }
+}

--- a/OptrixOS-Kernel/src/windows31_svg.c
+++ b/OptrixOS-Kernel/src/windows31_svg.c
@@ -1,0 +1,14 @@
+#include "windows31_svg.h"
+
+/*
+ * Trimmed example of a Windows 3.1 style window in SVG.
+ * This is not a full recreation but demonstrates usage of the
+ * svg_render() routine for drawing window decorations.
+ */
+const char windows31_svg[] =
+"<svg width='640' height='480'>"
+"<rect x='0' y='0' width='640' height='480' fill='#c0c7c8'/>"
+"<rect x='68' y='48' width='512' height='336' fill='#c0c0c0'/>"
+"<rect x='70' y='50' width='508' height='332' fill='#c0c0c0'/>"
+"<rect x='71' y='51' width='506' height='18' fill='#a0a0a0'/>"
+"</svg>";


### PR DESCRIPTION
## Summary
- allow larger file content with `FS_CONTENT_MAX`
- implement simple SVG parser for `<rect>` elements
- render example SVG on the desktop
- provide basic `memcpy` and `memset`
- embed small Windows 3.1 style SVG asset
- compile new objects via updated `Makefile`

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6850c6570264832fb4a77e0b4681f902