### PR TITLE
Implement simple window manager and CPU core handler

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -5,7 +5,7 @@ all: disk.img
 bootloader.bin: asm/bootloader.asm
 	@nasm -f bin $< -o $@
 	
-kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o src/driver.o src/mem.o src/kernel_main.o
+kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o src/driver.o src/mem.o src/taskbar.o src/scheduler.o src/terminal.o src/exec.o src/window.o src/window_manager.o src/cpu_core.o src/kernel_main.o
 	@nasm -f elf32 asm/kernel.asm -o kernel_asm.o
 	@nasm -f elf32 asm/ports.asm -o ports.o
 	@gcc $(CFLAGS) -c src/graphics.c -o src/graphics.o
@@ -18,11 +18,18 @@ kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboar
 	@gcc $(CFLAGS) -c src/mouse.c -o src/mouse.o
 	@gcc $(CFLAGS) -c src/driver.c -o src/driver.o
 	@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
+	@gcc $(CFLAGS) -c src/taskbar.c -o src/taskbar.o
+	@gcc $(CFLAGS) -c src/scheduler.c -o src/scheduler.o
+	@gcc $(CFLAGS) -c src/terminal.c -o src/terminal.o
+	@gcc $(CFLAGS) -c src/exec.c -o src/exec.o
+	@gcc $(CFLAGS) -c src/window.c -o src/window.o
+	@gcc $(CFLAGS) -c src/window_manager.c -o src/window_manager.o
+	@gcc $(CFLAGS) -c src/cpu_core.c -o src/cpu_core.o
 	@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
-    @ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
-    src/graphics.o src/screen.o src/keyboard.o \
-    src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o \
-    src/driver.o src/mem.o src/kernel_main.o --oformat binary -o $@
+	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
+src/graphics.o src/screen.o src/keyboard.o \
+src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o \
+src/driver.o src/mem.o src/taskbar.o src/scheduler.o src/terminal.o src/exec.o src/window.o src/window_manager.o src/cpu_core.o src/kernel_main.o --oformat binary -o $@
 	
 disk.img: bootloader.bin kernel.bin
 	@cat bootloader.bin kernel.bin > $@

--- a/OptrixOS-Kernel/include/cpu_core.h
+++ b/OptrixOS-Kernel/include/cpu_core.h
@@ -1,0 +1,10 @@
+#ifndef CPU_CORE_H
+#define CPU_CORE_H
+
+#include "scheduler.h"
+
+void cpu_core_init(void);
+void cpu_core_add_task(task_func_t func, void *arg);
+void cpu_core_run(void);
+
+#endif

--- a/OptrixOS-Kernel/include/desktop.h
+++ b/OptrixOS-Kernel/include/desktop.h
@@ -3,7 +3,7 @@
 
 void desktop_init(void);
 void desktop_run(void);
-/* Redraws a portion of the desktop wallpaper and icons. */
+/* Redraws a portion of the desktop wallpaper and main window. */
 void desktop_redraw_region(int x, int y, int w, int h);
 
 #endif

--- a/OptrixOS-Kernel/include/window_manager.h
+++ b/OptrixOS-Kernel/include/window_manager.h
@@ -1,0 +1,11 @@
+#ifndef WINDOW_MANAGER_H
+#define WINDOW_MANAGER_H
+
+#include "window.h"
+
+void window_manager_init(void);
+void window_manager_add(window_t *win);
+void window_manager_draw(void);
+void window_manager_handle_mouse(int mx, int my, int click);
+
+#endif

--- a/OptrixOS-Kernel/src/cpu_core.c
+++ b/OptrixOS-Kernel/src/cpu_core.c
@@ -1,0 +1,13 @@
+#include "cpu_core.h"
+
+void cpu_core_init(void) {
+    scheduler_init();
+}
+
+void cpu_core_add_task(task_func_t func, void *arg) {
+    scheduler_add(func, arg);
+}
+
+void cpu_core_run(void) {
+    scheduler_run();
+}

--- a/OptrixOS-Kernel/src/desktop.c
+++ b/OptrixOS-Kernel/src/desktop.c
@@ -3,6 +3,7 @@
 #include "graphics.h"
 #include "mouse.h"
 #include "fs.h"
+#include "window_manager.h"
 
 #define TEXT_COLOR 0x00
 
@@ -28,16 +29,6 @@ static void draw_bevel_rect(int x, int y, int w, int h,
     draw_rect(x+w-2, y, 2, h, sh);
 }
 
-static void draw_group_icon(int x, int y, const char *label) {
-    draw_rect(x, y, 48, 48, DESKTOP_BG_COLOR);
-    draw_rect(x+8, y+8, 20, 16, 0x0F);
-    draw_rect(x+12, y+12, 20, 16, 0x07);
-    put_pixel(x+20, y+14, 0x04);
-    put_pixel(x+22, y+14, 0x02);
-    put_pixel(x+24, y+14, 0x01);
-    int w = str_len(label) * CHAR_WIDTH;
-    draw_text(x + (48 - w)/2, y+32, label, TEXT_COLOR);
-}
 
 static void draw_wallpaper(void) {
     for(int y=0; y<SCREEN_HEIGHT; y++)
@@ -45,11 +36,11 @@ static void draw_wallpaper(void) {
             put_pixel(x, y, DESKTOP_BG_COLOR);
 }
 
-static void draw_demo_window(void) {
-    const int x = 68;
-    const int y = 48;
-    const int w = 512;
-    const int h = 336;
+static void draw_simple_window(void) {
+    const int w = 480;
+    const int h = 360;
+    const int x = (640 - w)/2;
+    const int y = (480 - h)/2;
     const uint8_t hl = 0x0F; /* highlight */
     const uint8_t sh = 0x08; /* shadow */
     const uint8_t mid = 0x07; /* medium grey */
@@ -73,17 +64,13 @@ static void draw_demo_window(void) {
     const int title_h = 19;
     draw_rect(x+3, y+3, w-6, title_h, mid);
 
-    /* program icon */
+    /* icon placeholder */
     int icon_x = x + 9;
     int icon_y = y + 6;
-    draw_rect(icon_x-1, icon_y-1, 13, 13, TEXT_COLOR);
-    draw_rect(icon_x, icon_y, 6, 6, 0x04);
-    draw_rect(icon_x+7, icon_y, 6, 6, 0x02);
-    draw_rect(icon_x, icon_y+7, 6, 6, 0x01);
-    draw_rect(icon_x+7, icon_y+7, 6, 6, 0x0E);
+    draw_rect(icon_x, icon_y, 13, 13, TEXT_COLOR);
 
     /* window title */
-    const char *title = "Program Manager";
+    const char *title = "Test UI";
     int title_w = str_len(title) * CHAR_WIDTH;
     draw_text(x + (w - title_w)/2, y + 7, title, TEXT_COLOR);
 
@@ -109,52 +96,19 @@ static void draw_demo_window(void) {
     draw_text(x+192, menu_y+4, "Help", TEXT_COLOR);
     draw_rect(x+3+176, menu_y+2, 1, menu_h-4, sh);
 
-    /* client area below menu */
+    /* client area */
     int div2_y = menu_y + menu_h;
     draw_rect(x+3, div2_y, w-6, 1, sh);
     int client_y = div2_y + 1;
     int client_h = h - (client_y - y) - 3;
     draw_rect(x+3, client_y, w-6, client_h, mid);
-
-    /* dialog box */
-    int dlg_w = 316, dlg_h = 162;
-    int dlg_x = x + (w - dlg_w)/2;
-    int dlg_y = client_y + (client_h - dlg_h)/2;
-    draw_bevel_rect(dlg_x, dlg_y, dlg_w, dlg_h, hl, sh, 0x0F);
-    draw_rect(dlg_x+2, dlg_y+2, dlg_w-4, 9, 0x01);
-    draw_rect(dlg_x+2, dlg_y+2, dlg_w-4, 1, hl);
-    int logo_x = dlg_x + (dlg_w-16)/2;
-    int logo_y = dlg_y+4;
-    draw_rect(logo_x, logo_y, 7,7,0x04);
-    draw_rect(logo_x+8, logo_y, 7,7,0x02);
-    draw_rect(logo_x, logo_y+8,7,7,0x01);
-    draw_rect(logo_x+8, logo_y+8,7,7,0x0E);
-    draw_text(dlg_x + 10, dlg_y + 28,
-              "386 Enhanced Mode Windows Version 3.10", TEXT_COLOR);
-    draw_text(dlg_x + 10, dlg_y + 40,
-              "Copyright (c) 1991, Microsoft Corp.", TEXT_COLOR);
-    int ok_w = 60, ok_h = 18;
-    int ok_x = dlg_x + (dlg_w - ok_w)/2;
-    int ok_y = dlg_y + dlg_h - ok_h - 10;
-    draw_bevel_rect(ok_x, ok_y, ok_w, ok_h, hl, sh, mid);
-    draw_text(ok_x + (ok_w - 2*CHAR_WIDTH)/2, ok_y + 4, "OK", TEXT_COLOR);
-
-    /* program group icons */
-    const char *names[6] = {
-        "Accessories","Games","StartUp",
-        "Applications","Main","Office"
-    };
-    int groups_y = client_y + client_h - 60;
-    for(int i=0;i<6;i++) {
-        int gx = x + 16 + i*(48+32);
-        draw_group_icon(gx, groups_y, names[i]);
-    }
 }
 
 void desktop_init(void) {
     fs_init();
     draw_wallpaper();
-    draw_demo_window();
+    window_manager_init();
+    draw_simple_window();
 }
 
 void desktop_run(void) {
@@ -163,6 +117,7 @@ void desktop_run(void) {
     mouse_draw(DESKTOP_BG_COLOR);
     while(1) {
         mouse_update();
+        window_manager_handle_mouse(mouse_get_x(), mouse_get_y(), mouse_clicked());
         mouse_draw(DESKTOP_BG_COLOR);
     }
 }
@@ -170,5 +125,5 @@ void desktop_run(void) {
 void desktop_redraw_region(int x, int y, int w, int h) {
     (void)x; (void)y; (void)w; (void)h;
     draw_wallpaper();
-    draw_demo_window();
+    draw_simple_window();
 }

--- a/OptrixOS-Kernel/src/kernel_main.c
+++ b/OptrixOS-Kernel/src/kernel_main.c
@@ -3,6 +3,7 @@
 #include "desktop.h"
 #include "driver.h"
 #include "mem.h"
+#include "cpu_core.h"
 
 /* simple heap placed at 0x200000 for illustration */
 #define HEAP_BASE ((unsigned char*)0x200000)
@@ -14,5 +15,7 @@ void kernel_main(void) {
     mem_init(HEAP_BASE, HEAP_SIZE);
     driver_init_all();
     desktop_init();
-    desktop_run();
+    cpu_core_init();
+    cpu_core_add_task((task_func_t)desktop_run, NULL);
+    cpu_core_run();
 }

--- a/OptrixOS-Kernel/src/window_manager.c
+++ b/OptrixOS-Kernel/src/window_manager.c
@@ -1,0 +1,35 @@
+#include "window_manager.h"
+#include "taskbar.h"
+
+#define MAX_WINDOWS 16
+
+static window_t *windows[MAX_WINDOWS];
+static int window_count = 0;
+
+void window_manager_init(void) {
+    window_count = 0;
+}
+
+void window_manager_add(window_t *win) {
+    if(window_count < MAX_WINDOWS) {
+        windows[window_count++] = win;
+        taskbar_register(win);
+    }
+}
+
+void window_manager_draw(void) {
+    for(int i=0;i<window_count;i++)
+        window_draw(windows[i]);
+}
+
+void window_manager_handle_mouse(int mx, int my, int click) {
+    for(int i=window_count-1;i>=0;i--) {
+        window_handle_mouse(windows[i], mx, my, click);
+        if(windows[i]->closed) {
+            taskbar_unregister(windows[i]);
+            for(int j=i;j<window_count-1;j++)
+                windows[j] = windows[j+1];
+            window_count--;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add basic window manager interface and CPU core handler
- remove demo extras and draw a minimal "Test UI" window
- integrate scheduler through cpu_core in `kernel_main`
- compile new modules via Makefile

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6850cc3b4ddc832f8c09cce6ee775490