### PR TITLE
Add container manager and CPU driver

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -1,34 +1,40 @@
 CFLAGS=-ffreestanding -fno-pie -fno-pic -m32 -Iinclude
-	
 all: disk.img
-	
+		
 bootloader.bin: asm/bootloader.asm
-	@nasm -f bin $< -o $@
-	
-kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o src/driver.o src/mem.o src/kernel_main.o
-	@nasm -f elf32 asm/kernel.asm -o kernel_asm.o
-	@nasm -f elf32 asm/ports.asm -o ports.o
-	@gcc $(CFLAGS) -c src/graphics.c -o src/graphics.o
-	@gcc $(CFLAGS) -c src/screen.c -o src/screen.o
-	@gcc $(CFLAGS) -c src/keyboard.c -o src/keyboard.o
-	@gcc $(CFLAGS) -c src/fs.c -o src/fs.o
-	@gcc $(CFLAGS) -c src/boot_logo.c -o src/boot_logo.o
-	@gcc $(CFLAGS) -c src/login.c -o src/login.o
+		@nasm -f bin $< -o $@
+		
+kernel.bin: asm/kernel.asm asm/ports.asm src/graphics.o src/screen.o src/keyboard.o src/fs.o src/boot_logo.o src/login.o src/desktop.o src/container.o src/window.o src/taskbar.o src/terminal.o src/mouse.o src/driver.o src/cpu_driver.o src/cpu.o src/mem.o src/kernel_main.o
+		@nasm -f elf32 asm/kernel.asm -o kernel_asm.o
+		@nasm -f elf32 asm/ports.asm -o ports.o
+		@gcc $(CFLAGS) -c src/graphics.c -o src/graphics.o
+		@gcc $(CFLAGS) -c src/screen.c -o src/screen.o
+		@gcc $(CFLAGS) -c src/keyboard.c -o src/keyboard.o
+		@gcc $(CFLAGS) -c src/fs.c -o src/fs.o
+		@gcc $(CFLAGS) -c src/boot_logo.c -o src/boot_logo.o
+		@gcc $(CFLAGS) -c src/login.c -o src/login.o
 	@gcc $(CFLAGS) -c src/desktop.c -o src/desktop.o
+	@gcc $(CFLAGS) -c src/container.c -o src/container.o
+	@gcc $(CFLAGS) -c src/window.c -o src/window.o
+	@gcc $(CFLAGS) -c src/taskbar.c -o src/taskbar.o
+	@gcc $(CFLAGS) -c src/terminal.c -o src/terminal.o
 	@gcc $(CFLAGS) -c src/mouse.c -o src/mouse.o
-	@gcc $(CFLAGS) -c src/driver.c -o src/driver.o
-	@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
-	@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
-    @ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
-    src/graphics.o src/screen.o src/keyboard.o \
-    src/fs.o src/boot_logo.o src/login.o src/desktop.o src/mouse.o \
-    src/driver.o src/mem.o src/kernel_main.o --oformat binary -o $@
-	
+		@gcc $(CFLAGS) -c src/driver.c -o src/driver.o
+		@gcc $(CFLAGS) -c src/cpu_driver.c -o src/cpu_driver.o
+		@gcc $(CFLAGS) -c src/cpu.c -o src/cpu.o
+		@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
+		@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
+	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
+	src/graphics.o src/screen.o src/keyboard.o \
+src/fs.o src/boot_logo.o src/login.o src/desktop.o src/container.o src/window.o \
+src/taskbar.o src/terminal.o src/mouse.o \
+src/driver.o src/cpu_driver.o src/cpu.o src/mem.o src/kernel_main.o --oformat binary -o $@
+		
 disk.img: bootloader.bin kernel.bin
-	@cat bootloader.bin kernel.bin > $@
-	
+		@cat bootloader.bin kernel.bin > $@
+		
 run: disk.img
-	@qemu-system-i386 -drive format=raw,file=disk.img
-	
+		@qemu-system-i386 -drive format=raw,file=disk.img
+		
 clean:
-	@rm -f *.bin *.o disk.img src/*.o kernel_asm.o
+		@rm -f *.bin *.o disk.img src/*.o kernel_asm.o

--- a/OptrixOS-Kernel/include/container.h
+++ b/OptrixOS-Kernel/include/container.h
@@ -1,0 +1,14 @@
+#ifndef CONTAINER_H
+#define CONTAINER_H
+
+#include "window.h"
+
+#define MAX_WINDOWS 8
+
+void container_init(void);
+window_t* container_create(int x, int y, int w, int h, const char *title,
+                           uint8_t color, uint8_t bg_color);
+void container_draw(void);
+void container_handle_mouse(int mx, int my, int click);
+
+#endif

--- a/OptrixOS-Kernel/include/cpu.h
+++ b/OptrixOS-Kernel/include/cpu.h
@@ -1,0 +1,13 @@
+#ifndef CPU_H
+#define CPU_H
+#include <stdint.h>
+
+typedef struct {
+    char vendor[13];
+    uint32_t features_ecx;
+    uint32_t features_edx;
+} cpu_info_t;
+
+void cpu_detect(cpu_info_t *info);
+
+#endif

--- a/OptrixOS-Kernel/include/cpu_driver.h
+++ b/OptrixOS-Kernel/include/cpu_driver.h
@@ -1,0 +1,6 @@
+#ifndef CPU_DRIVER_H
+#define CPU_DRIVER_H
+
+void cpu_driver_register(void);
+
+#endif

--- a/OptrixOS-Kernel/src/container.c
+++ b/OptrixOS-Kernel/src/container.c
@@ -1,0 +1,36 @@
+#include "container.h"
+#include "taskbar.h"
+
+static window_t windows[MAX_WINDOWS];
+static int window_count = 0;
+
+void container_init(void) {
+    window_count = 0;
+}
+
+window_t* container_create(int x, int y, int w, int h, const char *title,
+                           uint8_t color, uint8_t bg_color) {
+    if(window_count >= MAX_WINDOWS)
+        return 0;
+    window_t *win = &windows[window_count++];
+    window_init(win, x, y, w, h, title, color, bg_color);
+    taskbar_register(win);
+    return win;
+}
+
+void container_draw(void) {
+    for(int i=0; i<window_count; i++)
+        window_draw(&windows[i]);
+}
+
+void container_handle_mouse(int mx, int my, int click) {
+    for(int i=window_count-1; i>=0; i--) {
+        window_handle_mouse(&windows[i], mx, my, click);
+        if(windows[i].closed) {
+            taskbar_unregister(&windows[i]);
+            for(int j=i; j<window_count-1; j++)
+                windows[j] = windows[j+1];
+            window_count--;
+        }
+    }
+}

--- a/OptrixOS-Kernel/src/cpu.c
+++ b/OptrixOS-Kernel/src/cpu.c
@@ -1,0 +1,16 @@
+#include "cpu.h"
+
+void cpu_detect(cpu_info_t *info) {
+    if(!info) return;
+    uint32_t eax, ebx, ecx, edx;
+    char vendor[13];
+    __asm__ volatile ("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(0));
+    *(uint32_t*)&vendor[0] = ebx;
+    *(uint32_t*)&vendor[4] = edx;
+    *(uint32_t*)&vendor[8] = ecx;
+    vendor[12] = 0;
+    for(int i=0;i<13;i++) info->vendor[i]=vendor[i];
+    __asm__ volatile ("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(1));
+    info->features_ecx = ecx;
+    info->features_edx = edx;
+}

--- a/OptrixOS-Kernel/src/cpu_driver.c
+++ b/OptrixOS-Kernel/src/cpu_driver.c
@@ -1,0 +1,16 @@
+#include "cpu.h"
+#include "driver.h"
+#include "mem.h"
+
+static cpu_info_t cpu_info;
+
+static void init(void) {
+    cpu_detect(&cpu_info);
+    (void)cpu_info; /* info is stored for later use */
+}
+
+static driver_t drv = { "cpu", init, 0 };
+
+void cpu_driver_register(void) {
+    driver_register(&drv);
+}

--- a/OptrixOS-Kernel/src/kernel_main.c
+++ b/OptrixOS-Kernel/src/kernel_main.c
@@ -2,6 +2,7 @@
 #include "boot_logo.h"
 #include "desktop.h"
 #include "driver.h"
+#include "cpu_driver.h"
 #include "mem.h"
 
 /* simple heap placed at 0x200000 for illustration */
@@ -12,6 +13,7 @@ void kernel_main(void) {
     screen_init();
     boot_logo();
     mem_init(HEAP_BASE, HEAP_SIZE);
+    cpu_driver_register();
     driver_init_all();
     desktop_init();
     desktop_run();

--- a/OptrixOS-Kernel/src/window.c
+++ b/OptrixOS-Kernel/src/window.c
@@ -54,16 +54,35 @@ void window_draw(window_t* win) {
         return;
     }
 
-    int show_bar = 1;
-    /* shadow */
-    draw_rounded_rect(x+2, y+2, w, h, 6, win->bg_color);
-    /* container */
-    draw_rect(x, y+14, w, h-14, win->color);
-    /* top bar with rounded corners */
-    draw_rounded_rect(x, y, w, 14, 6, 0x01);
-    if(show_bar) {
-        draw_buttons(x+w, y);
+    int bar_h = 16;
+    const uint8_t border = 0x07;   /* grey */
+    const uint8_t highlight = 0x0F;/* white */
+    const uint8_t shadow = 0x08;   /* dark grey */
+
+    /* outer frame */
+    draw_rect(x, y, w, h, border);
+    draw_rect(x, y, w, 1, highlight);          /* top highlight */
+    draw_rect(x, y, 1, h, highlight);          /* left highlight */
+    draw_rect(x, y+h-1, w, 1, shadow);         /* bottom shadow */
+    draw_rect(x+w-1, y, 1, h, shadow);         /* right shadow */
+
+    /* title bar */
+    draw_rect(x+2, y+2, w-4, bar_h-2, border);
+    draw_rect(x+2, y+2, w-4, 1, highlight);
+    draw_rect(x+2, y+bar_h-1, w-4, 1, shadow);
+
+    /* client area */
+    draw_rect(x+2, y+bar_h, w-4, h-bar_h-2, win->color);
+
+    /* window title centered */
+    if(win->title) {
+        int len=0; while(win->title[len]) len++;
+        int tx = x + (w - len*CHAR_WIDTH)/2;
+        for(int c=0;c<len;c++)
+            screen_put_char_offset(c,0,win->title[c],0x00,tx, y+4);
     }
+
+    draw_buttons(x+w-4, y+2);
 }
 
 void window_handle_mouse(window_t *win, int mx, int my, int click) {


### PR DESCRIPTION
## Summary
- introduce a `container` manager to handle multiple windows
- update window drawing to use a 3D gray style with centered title
- create a simple CPU feature detection driver
- register the CPU driver during boot
- adjust build system for new sources

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_6850d38e1ccc832fb12b6a4375668016