### PR TITLE
Fix build to include GUI

### DIFF
--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -268,10 +268,6 @@ def main():
     asm_files, c_files, h_files = collect_source_files(KERNEL_PROJECT_ROOT)
     # Exclude the old scheduler from builds
     c_files = [f for f in c_files if not f.endswith('scheduler.c')]
-    c_files = [f for f in c_files if not f.endswith('terminal.c')]
-    c_files = [f for f in c_files if not f.endswith('exec.c')]
-    c_files = [f for f in c_files if not f.endswith('taskbar.c')]
-    c_files = [f for f in c_files if not f.endswith('window.c')]
     print(f"Found {len(asm_files)} asm, {len(c_files)} c, {len(h_files)} h files.")
     boot_bin, kernel_bin = build_kernel(asm_files, c_files, out_bin=KERNEL_BIN)
     make_dynamic_img(boot_bin, kernel_bin, DISK_IMG)


### PR DESCRIPTION
## Summary
- include windowing and taskbar sources when building the kernel

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs.exe not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d58536d0832f86a2bf36d65c823e