### PR TITLE
Improve window buttons and cursor

### DIFF
--- a/OptrixOS-Kernel/include/mouse.h
+++ b/OptrixOS-Kernel/include/mouse.h
@@ -11,6 +11,7 @@ int mouse_clicked(void);
 int mouse_is_present(void);
 void mouse_set_visible(int vis);
 int mouse_get_visible(void);
-void mouse_draw(uint8_t bg_color);
+void mouse_draw(void);
+void mouse_clear(void);
 
 #endif

--- a/OptrixOS-Kernel/src/desktop.c
+++ b/OptrixOS-Kernel/src/desktop.c
@@ -22,19 +22,19 @@ void desktop_init(void) {
     taskbar_init();
     draw_wallpaper();
     container_init();
-    test_win = container_create(96, 72, 512, 336, "Test Window", 0x0F, 0x17);
+    test_win = container_create(96, 72, 512, 336, "Test Window", 0x02, 0x00);
     terminal_set_window(test_win);
 }
 
 void desktop_run(void) {
     mouse_init();
     mouse_set_visible(1);
-    mouse_draw(DESKTOP_BG_COLOR);
     while(1) {
         mouse_update();
+        mouse_clear();
         container_handle_mouse(mouse_get_x(), mouse_get_y(), mouse_clicked());
         container_draw();
-        mouse_draw(DESKTOP_BG_COLOR);
+        mouse_draw();
     }
 }
 

--- a/OptrixOS-Kernel/src/mouse.c
+++ b/OptrixOS-Kernel/src/mouse.c
@@ -10,46 +10,67 @@ static int clicked = 0;
 static int mouse_present = 0;
 static int cursor_visible = 1;
 static int prev_x = -1, prev_y = -1;
-#define CURSOR_W 6
-#define CURSOR_H 9
+#define CURSOR_W 8
+#define CURSOR_H 12
 static uint8_t saved_bg[CURSOR_H][CURSOR_W];
 
 static const uint8_t cursor_shape[CURSOR_H] = {
-    0b100000,
-    0b110000,
-    0b111000,
-    0b111100,
-    0b111110,
-    0b111111,
-    0b011110,
-    0b001100,
-    0b000000
+    0x80,
+    0xC0,
+    0xE0,
+    0xF0,
+    0xF8,
+    0xFC,
+    0xFE,
+    0x7C,
+    0x38,
+    0x30,
+    0x00,
+    0x00
+};
+
+static const uint8_t cursor_outline[CURSOR_H] = {
+    0xE0,
+    0xF0,
+    0xF8,
+    0xFC,
+    0xFE,
+    0xFF,
+    0xFF,
+    0xFF,
+    0xFE,
+    0x7C,
+    0x78,
+    0x00
 };
 
 void mouse_set_visible(int vis) { cursor_visible = vis; }
 int mouse_get_visible(void) { return cursor_visible; }
 
-void mouse_draw(uint8_t bg_color) {
-    (void)bg_color;
+void mouse_clear(void) {
     if(prev_x != -1 && prev_y != -1 && cursor_visible) {
         for(int dy=0; dy<CURSOR_H; dy++)
             for(int dx=0; dx<CURSOR_W; dx++)
                 put_pixel(prev_x+dx, prev_y+dy, saved_bg[dy][dx]);
+        prev_x = -1;
+        prev_y = -1;
     }
-    if(cursor_visible) {
-        for(int dy=0; dy<CURSOR_H; dy++)
-            for(int dx=0; dx<CURSOR_W; dx++)
-                saved_bg[dy][dx] = get_pixel(mx+dx, my+dy);
-        for(int dy=0; dy<CURSOR_H; dy++) {
-            for(int dx=0; dx<CURSOR_W; dx++) {
-                if(cursor_shape[dy] & (1 << (CURSOR_W-1-dx)))
-                    put_pixel(mx+dx, my+dy, 0x0F);
-            }
-        }
-        prev_x = mx; prev_y = my;
-    } else {
-        prev_x = prev_y = -1;
-    }
+}
+
+void mouse_draw(void) {
+    if(!cursor_visible) return;
+    for(int dy=0; dy<CURSOR_H; dy++)
+        for(int dx=0; dx<CURSOR_W; dx++)
+            saved_bg[dy][dx] = get_pixel(mx+dx, my+dy);
+    for(int dy=0; dy<CURSOR_H; dy++)
+        for(int dx=0; dx<CURSOR_W; dx++)
+            if(cursor_outline[dy] & (1 << (CURSOR_W-1-dx)))
+                put_pixel(mx+dx, my+dy, 0x00);
+    for(int dy=0; dy<CURSOR_H; dy++)
+        for(int dx=0; dx<CURSOR_W; dx++)
+            if(cursor_shape[dy] & (1 << (CURSOR_W-1-dx)))
+                put_pixel(mx+dx, my+dy, 0x0F);
+    prev_x = mx; prev_y = my;
 }
 
 static void mouse_wait_input(void) {

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -175,14 +175,15 @@ static void read_line(char* buf, size_t max, window_t *win) {
     int blink = 0;
     cursor_on = 1;
     draw_cursor(1);
-    mouse_draw(BACKGROUND_COLOR);
+    mouse_draw();
     while(idx < max-1) {
         mouse_update();
+        mouse_clear();
         window_handle_mouse(win, mouse_get_x(), mouse_get_y(), mouse_clicked());
         if(!win->visible) { buf[0] = '\0'; break; }
         terminal_set_window(win);
         window_draw(win);
-        mouse_draw(BACKGROUND_COLOR);
+        mouse_draw();
         char c = keyboard_getchar();
         if(!c) {
             blink++;
@@ -227,7 +228,7 @@ static void read_line(char* buf, size_t max, window_t *win) {
         buf[idx++] = c;
     }
     draw_cursor(0);
-    mouse_draw(BACKGROUND_COLOR);
+    mouse_draw();
     buf[idx] = '\0';
 }
 
@@ -600,7 +601,7 @@ static void execute(const char* line) {
 void terminal_run(window_t *win) {
     char buf[128];
     mouse_set_visible(1);
-    mouse_draw(BACKGROUND_COLOR);
+    mouse_draw();
     while(win->visible) {
         print("> ");
         read_line(buf, sizeof(buf), win);

--- a/OptrixOS-Kernel/src/window.c
+++ b/OptrixOS-Kernel/src/window.c
@@ -32,10 +32,21 @@ void window_close(window_t *win) {
     taskbar_unregister(win);
 }
 
+static void draw_button(int bx, int by) {
+    const uint8_t base = 0x07;
+    const uint8_t highlight = 0x0F;
+    const uint8_t shadow = 0x08;
+    draw_rect(bx, by, 6, 6, base);
+    draw_rect(bx, by, 6, 1, highlight);
+    draw_rect(bx, by, 1, 6, highlight);
+    draw_rect(bx, by+5, 6, 1, shadow);
+    draw_rect(bx+5, by, 1, 6, shadow);
+}
+
 static void draw_buttons(int x, int y) {
-    draw_rounded_rect(x-36, y+3, 6, 6, 3, 0x04); /* close */
-    draw_rounded_rect(x-24, y+3, 6, 6, 3, 0x02); /* minimize */
-    draw_rounded_rect(x-12, y+3, 6, 6, 3, 0x03); /* maximize */
+    draw_button(x-36, y+3); /* close */
+    draw_button(x-24, y+3); /* minimize */
+    draw_button(x-12, y+3); /* maximize */
 }
 
 void window_draw(window_t* win) {


### PR DESCRIPTION
## Summary
- restyle window control buttons with a simple 3‑D look
- use a larger mouse cursor with black outline
- clear the cursor before redrawing windows to reduce flicker
- make the test window green on black for a more retro feel

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6850d72252e8832f844d6f9044f4d747