### PR TITLE
Improve window UI and add double buffering

### DIFF
--- a/OptrixOS-Kernel/include/graphics.h
+++ b/OptrixOS-Kernel/include/graphics.h
@@ -6,4 +6,6 @@ uint8_t get_pixel(int x, int y);
 void draw_rect(int x, int y, int w, int h, uint8_t color);
 void draw_rounded_rect(int x, int y, int w, int h, int r, uint8_t color);
 void graphics_set_framebuffer(uint32_t addr);
+void graphics_set_backbuffer(uint8_t *buf);
+void graphics_present(void);
 #endif

--- a/OptrixOS-Kernel/src/desktop.c
+++ b/OptrixOS-Kernel/src/desktop.c
@@ -6,6 +6,7 @@
 #include "container.h"
 #include "taskbar.h"
 #include "terminal.h"
+#include "mem.h"
 
 #define DESKTOP_BG_COLOR 0x17
 
@@ -22,7 +23,10 @@ void desktop_init(void) {
     taskbar_init();
     draw_wallpaper();
     container_init();
-    test_win = container_create(96, 72, 512, 336, "Test Window", 0x02, 0x00);
+    uint8_t *buf = mem_alloc(SCREEN_WIDTH * SCREEN_HEIGHT);
+    if(buf)
+        graphics_set_backbuffer(buf);
+    test_win = container_create(96, 72, 512, 336, "Test Window", 0x07, 0x00);
     terminal_set_window(test_win);
 }
 
@@ -35,6 +39,7 @@ void desktop_run(void) {
         container_handle_mouse(mouse_get_x(), mouse_get_y(), mouse_clicked());
         container_draw();
         mouse_draw();
+        graphics_present();
     }
 }
 

--- a/OptrixOS-Kernel/src/graphics.c
+++ b/OptrixOS-Kernel/src/graphics.c
@@ -4,20 +4,36 @@
 #define WIDTH 800
 #define HEIGHT 600
 static volatile uint8_t *VGA = (uint8_t *)0xA0000;
+static uint8_t *BACKBUF = 0;
 
 void graphics_set_framebuffer(uint32_t addr) {
     VGA = (volatile uint8_t *)addr;
 }
 
+void graphics_set_backbuffer(uint8_t *buf) {
+    BACKBUF = buf;
+}
+
+void graphics_present(void) {
+    if(!BACKBUF) return;
+    for(int i=0;i<WIDTH*HEIGHT;i++)
+        VGA[i] = BACKBUF[i];
+}
+
 void put_pixel(int x, int y, uint8_t color) {
     if (x < 0 || x >= WIDTH || y < 0 || y >= HEIGHT)
         return;
-    VGA[y * WIDTH + x] = color;
+    if(BACKBUF)
+        BACKBUF[y * WIDTH + x] = color;
+    else
+        VGA[y * WIDTH + x] = color;
 }
 
 uint8_t get_pixel(int x, int y) {
     if (x < 0 || x >= WIDTH || y < 0 || y >= HEIGHT)
         return 0;
+    if(BACKBUF)
+        return BACKBUF[y * WIDTH + x];
     return VGA[y * WIDTH + x];
 }
 

--- a/OptrixOS-Kernel/src/kernel_main.c
+++ b/OptrixOS-Kernel/src/kernel_main.c
@@ -7,7 +7,7 @@
 
 /* simple heap placed at 0x200000 for illustration */
 #define HEAP_BASE ((unsigned char*)0x200000)
-#define HEAP_SIZE (64*1024)
+#define HEAP_SIZE (512*1024)
 
 void kernel_main(void) {
     screen_init();

--- a/OptrixOS-Kernel/src/window.c
+++ b/OptrixOS-Kernel/src/window.c
@@ -36,17 +36,17 @@ static void draw_button(int bx, int by) {
     const uint8_t base = 0x07;
     const uint8_t highlight = 0x0F;
     const uint8_t shadow = 0x08;
-    draw_rect(bx, by, 6, 6, base);
-    draw_rect(bx, by, 6, 1, highlight);
-    draw_rect(bx, by, 1, 6, highlight);
-    draw_rect(bx, by+5, 6, 1, shadow);
-    draw_rect(bx+5, by, 1, 6, shadow);
+    draw_rect(bx, by, 8, 8, base);
+    draw_rect(bx, by, 8, 1, highlight);
+    draw_rect(bx, by, 1, 8, highlight);
+    draw_rect(bx, by+7, 8, 1, shadow);
+    draw_rect(bx+7, by, 1, 8, shadow);
 }
 
 static void draw_buttons(int x, int y) {
-    draw_button(x-36, y+3); /* close */
-    draw_button(x-24, y+3); /* minimize */
-    draw_button(x-12, y+3); /* maximize */
+    draw_button(x-40, y+4); /* close */
+    draw_button(x-26, y+4); /* minimize */
+    draw_button(x-12, y+4); /* maximize */
 }
 
 void window_draw(window_t* win) {
@@ -65,7 +65,7 @@ void window_draw(window_t* win) {
         return;
     }
 
-    int bar_h = 16;
+    int bar_h = 20;
     const uint8_t border = 0x07;   /* grey */
     const uint8_t highlight = 0x0F;/* white */
     const uint8_t shadow = 0x08;   /* dark grey */
@@ -90,7 +90,7 @@ void window_draw(window_t* win) {
         int len=0; while(win->title[len]) len++;
         int tx = x + (w - len*CHAR_WIDTH)/2;
         for(int c=0;c<len;c++)
-            screen_put_char_offset(c,0,win->title[c],0x00,tx, y+4);
+            screen_put_char_offset(c,0,win->title[c],0x0F,tx, y+6);
     }
 
     draw_buttons(x+w-4, y+2);
@@ -102,15 +102,16 @@ void window_handle_mouse(window_t *win, int mx, int my, int click) {
     int x = win->x; int y = win->y; int w = win->w; int h = win->h;
     if(win->state == 1) { x = 0; y = 0; w = SCREEN_WIDTH; h = SCREEN_HEIGHT; }
     int show_bar = 1;
+    int bar_h = 20;
 
     if(click && !drag && !resize) {
-        if(show_bar && my >= y && my < y+14 && mx >= x+w-36 && mx < x+w-26) {
+        if(show_bar && my >= y && my < y+bar_h-2 && mx >= x+w-40 && mx < x+w-32) {
             window_close(win);
             return;
-        } else if(show_bar && my >= y && my < y+14 && mx >= x+w-24 && mx < x+w-14) {
+        } else if(show_bar && my >= y && my < y+bar_h-2 && mx >= x+w-26 && mx < x+w-18) {
             win->state = 2; /* minimize */
             return;
-        } else if(show_bar && my >= y && my < y+14 && mx >= x+w-12 && mx < x+w) {
+        } else if(show_bar && my >= y && my < y+bar_h-2 && mx >= x+w-12 && mx < x+w-4) {
             if(win->state == 1) {
                 win->state = 0;
                 win->x = saved_x; win->y = saved_y; win->w = saved_w; win->h = saved_h;
@@ -119,7 +120,7 @@ void window_handle_mouse(window_t *win, int mx, int my, int click) {
                 win->state = 1;
             }
             return;
-        } else if(show_bar && my >= y && my < y+14) {
+        } else if(show_bar && my >= y && my < y+bar_h-2) {
             drag = 1; prev_mx = mx; prev_my = my;
         } else if(mx >= x+w-4 && my >= y+h-4) {
             resize = 1; prev_mx = mx; prev_my = my;


### PR DESCRIPTION
## Summary
- allocate a back buffer for the screen and present it each frame
- enlarge window title bar and buttons
- show window title text in white
- use a light grey background for the test window
- enlarge heap size for new buffer

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_6850d9728734832f973be3bf79e9052d