### PR TITLE
Add 80s style wallpaper with backbuffer support

### DIFF
--- a/OptrixOS-Kernel/src/desktop.c
+++ b/OptrixOS-Kernel/src/desktop.c
@@ -8,24 +8,45 @@
 #include "terminal.h"
 #include "mem.h"
 
-#define DESKTOP_BG_COLOR 0x1B /* Windows 95 teal */
+#define WALL_COLOR1 0x1B /* Windows 95 teal */
+#define WALL_COLOR2 0x13 /* darker teal */
+
+static uint8_t *wallpaper_buf = 0;
 
 static window_t *test_win = 0;
 
+static void init_wallpaper(void) {
+    wallpaper_buf = mem_alloc(SCREEN_WIDTH * SCREEN_HEIGHT);
+    if(!wallpaper_buf) return;
+    for(int y=0; y<SCREEN_HEIGHT; y++) {
+        for(int x=0; x<SCREEN_WIDTH; x++) {
+            uint8_t color = ((x/8 + y/8) % 2) ? WALL_COLOR1 : WALL_COLOR2;
+            wallpaper_buf[y * SCREEN_WIDTH + x] = color;
+        }
+    }
+}
+
 static void draw_wallpaper(void) {
-    for(int y=0; y<SCREEN_HEIGHT; y++)
-        for(int x=0; x<SCREEN_WIDTH; x++)
-            put_pixel(x, y, DESKTOP_BG_COLOR);
+    if(!wallpaper_buf)
+        init_wallpaper();
+    if(wallpaper_buf) {
+        for(int y=0; y<SCREEN_HEIGHT; y++) {
+            for(int x=0; x<SCREEN_WIDTH; x++) {
+                put_pixel(x, y, wallpaper_buf[y * SCREEN_WIDTH + x]);
+            }
+        }
+    }
 }
 
 void desktop_init(void) {
     fs_init();
     taskbar_init();
-    draw_wallpaper();
-    container_init();
     uint8_t *buf = mem_alloc(SCREEN_WIDTH * SCREEN_HEIGHT);
     if(buf)
         graphics_set_backbuffer(buf);
+    draw_wallpaper();
+    graphics_present();
+    container_init();
     test_win = container_create(96, 72, 512, 336, "Test Window", 0x07, 0x00);
     terminal_set_window(test_win);
 }
@@ -44,7 +65,18 @@ void desktop_run(void) {
 }
 
 void desktop_redraw_region(int x, int y, int w, int h) {
-    (void)x; (void)y; (void)w; (void)h;
-    draw_wallpaper();
+    if(wallpaper_buf) {
+        if(x < 0) { w += x; x = 0; }
+        if(y < 0) { h += y; y = 0; }
+        if(x + w > SCREEN_WIDTH)  w = SCREEN_WIDTH - x;
+        if(y + h > SCREEN_HEIGHT) h = SCREEN_HEIGHT - y;
+        for(int yy=y; yy<y+h; yy++) {
+            for(int xx=x; xx<x+w; xx++) {
+                put_pixel(xx, yy, wallpaper_buf[yy * SCREEN_WIDTH + xx]);
+            }
+        }
+    } else {
+        draw_wallpaper();
+    }
     container_draw();
 }


### PR DESCRIPTION
## Summary
- add an 80s-inspired patterned wallpaper
- allocate wallpaper buffer and draw to backbuffer during `desktop_init`
- redraw regions using wallpaper buffer

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850dc5ac4b0832f83d67bc92ba04182