### PR TITLE
Boot directly into terminal

### DIFF
--- a/OptrixOS-Kernel/src/kernel_main.c
+++ b/OptrixOS-Kernel/src/kernel_main.c
@@ -1,6 +1,6 @@
 #include "screen.h"
-#include "boot_logo.h"
-#include "desktop.h"
+#include "terminal.h"
+#include "window.h"
 #include "driver.h"
 #include "mem.h"
 
@@ -10,9 +10,13 @@
 
 void kernel_main(void) {
     screen_init();
-    boot_logo();
     mem_init(HEAP_BASE, HEAP_SIZE);
     driver_init_all();
-    desktop_init();
-    desktop_run();
+
+    static window_t term_win;
+    window_init(&term_win, 0, 0, SCREEN_WIDTH, SCREEN_HEIGHT,
+                "Terminal", 0x07, 0x00);
+    terminal_set_window(&term_win);
+    terminal_init();
+    terminal_run(&term_win);
 }

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -240,6 +240,7 @@ static void cmd_help(void) {
     print("ping  - check connectivity\n");
     print("reverse <text> - reverse a string\n");
     print("add <a> <b>   - add two numbers\n");
+    print("mul <a> <b>   - multiply two numbers\n");
     print("color <hex>  - set text color\n");
     print("border      - redraw border\n");
     print("dir         - list directory contents\n");
@@ -257,6 +258,7 @@ static void cmd_help(void) {
     print("hello      - greet the user\n");
     print("uptime     - show uptime counter\n");
     print("meminfo    - show memory usage\n");
+    print("rand       - random number\n");
 }
 
 static void cmd_clear(void) {
@@ -307,6 +309,38 @@ static void cmd_add(const char* args) {
     }
     if(neg) b = -b;
     print_int(a + b);
+    putchar('\n');
+}
+
+static void cmd_mul(const char* args) {
+    int a = 0, b = 0;
+    int idx = 0;
+    int neg = 0;
+    while(args[idx] == ' ') idx++;
+    if(args[idx] == '-') { neg = 1; idx++; }
+    while(args[idx] >= '0' && args[idx] <= '9') {
+        a = a*10 + (args[idx]-'0');
+        idx++;
+    }
+    if(neg) a = -a;
+    while(args[idx] == ' ') idx++;
+    neg = 0;
+    if(args[idx] == '-') { neg = 1; idx++; }
+    while(args[idx] >= '0' && args[idx] <= '9') {
+        b = b*10 + (args[idx]-'0');
+        idx++;
+    }
+    if(neg) b = -b;
+    print_int(a * b);
+    putchar('\n');
+}
+
+static unsigned int rand_state = 1234567;
+static void cmd_rand(void) {
+    rand_state ^= rand_state << 13;
+    rand_state ^= rand_state >> 17;
+    rand_state ^= rand_state << 5;
+    print_int((int)(rand_state & 0x7fffffff));
     putchar('\n');
 }
 
@@ -552,6 +586,8 @@ static void execute(const char* line) {
         cmd_reverse(line+8);
     } else if(strprefix(line, "add ")) {
         cmd_add(line+4);
+    } else if(strprefix(line, "mul ")) {
+        cmd_mul(line+4);
     } else if(strprefix(line, "color ")) {
         cmd_color(line+6);
     } else if(streq(line, "border")) {
@@ -590,6 +626,8 @@ static void execute(const char* line) {
         cmd_uptime();
     } else if(streq(line, "meminfo")) {
         cmd_meminfo();
+    } else if(streq(line, "rand")) {
+        cmd_rand();
     } else if(streq(line, "ls")) {
         cmd_dir();
     } else if(line[0]) {

--- a/README.md
+++ b/README.md
@@ -48,13 +48,11 @@ qemu-system-x86_64 -hda disk.img
 
 ## Built-in terminal
 
-After boot a login prompt asks for the admin password (`admin1`). Once logged
-in a simple text terminal is available. The screen now runs in a
-high‑resolution 800x600 graphics mode with characters rendered at a 21‑pixel
-size. A title bar with a box-drawing border is drawn using VGA graphics
-characters. The background is white with black text while the cursor is
-rendered in bright yellow. The hardware text mode cursor is disabled so only the
-custom cursor is visible. The terminal automatically scrolls as it fills.
+After boot the system now launches directly into a full screen terminal without
+showing the previous desktop UI or login prompt. The screen still runs in the
+800x600 graphics mode with characters rendered at a 21‑pixel size. The custom
+cursor and box-drawing title bar remain and the terminal automatically scrolls
+as it fills.
 The following commands are implemented:
 
 * `help`    - display available commands
@@ -64,6 +62,7 @@ The following commands are implemented:
 * `ping`    - check connectivity
 * `reverse` - reverse a string
 * `add`     - add two numbers
+* `mul`     - multiply two numbers
 * `color`   - set the text colour
 * `border`  - redraw the terminal border
 * `dir`     - list directory contents
@@ -82,6 +81,7 @@ The following commands are implemented:
 * `rmdir`   - remove an empty directory
   (directory capacity has been increased to support more entries)
 * `cp`      - copy a file
+* `rand`    - generate a random number
 * `ls`      - alias of `dir`
 * `shutdown`- halt the system
 


### PR DESCRIPTION
## Summary
- drop desktop UI and boot logo
- add new `mul` and `rand` commands
- document direct terminal boot and new commands

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_685300774758832fb91f4c6632dde4d6