### PR TITLE
Fix bootloader drive detection

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -17,6 +17,7 @@ start:
     mov es, ax
     mov ss, ax
     mov sp, 0x7C00
+    mov [BOOT_DRIVE], dl
 
     ; Set 80x25 text mode
     mov ax, 0x0003


### PR DESCRIPTION
## Summary
- store the BIOS boot drive number in the bootloader

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68532534ee4c832f85cbc5795516f3d5