### PR TITLE
Add simple disk-based filesystem loader

### DIFF
--- a/OptrixOS-Kernel/asm/ports.asm
+++ b/OptrixOS-Kernel/asm/ports.asm
@@ -2,6 +2,8 @@
 
 GLOBAL inb
 GLOBAL outb
+GLOBAL inw
+GLOBAL outw
 
 inb:
     mov edx, [esp+4]
@@ -13,4 +15,16 @@ outb:
     mov edx, [esp+4]
     mov al, [esp+8]
     out dx, al
+    ret
+
+inw:
+    mov edx, [esp+4]
+    in ax, dx
+    movzx eax, ax
+    ret
+
+outw:
+    mov edx, [esp+4]
+    mov ax, [esp+8]
+    out dx, ax
     ret

--- a/OptrixOS-Kernel/include/build_params.h
+++ b/OptrixOS-Kernel/include/build_params.h
@@ -1,0 +1,6 @@
+#ifndef BUILD_PARAMS_H
+#define BUILD_PARAMS_H
+#define KERNEL_SECTORS 24
+#define FS_START_SECTOR 25
+#define FS_SECTORS 1
+#endif

--- a/OptrixOS-Kernel/include/disk.h
+++ b/OptrixOS-Kernel/include/disk.h
@@ -1,0 +1,6 @@
+#ifndef DISK_H
+#define DISK_H
+#include <stdint.h>
+void ata_read_sector(uint32_t lba, uint8_t *buffer);
+void ata_read_sectors(uint32_t lba, uint8_t count, uint8_t *buffer);
+#endif

--- a/OptrixOS-Kernel/include/ports.h
+++ b/OptrixOS-Kernel/include/ports.h
@@ -3,4 +3,6 @@
 #include <stdint.h>
 uint8_t inb(uint16_t port);
 void outb(uint16_t port, uint8_t data);
+uint16_t inw(uint16_t port);
+void outw(uint16_t port, uint16_t data);
 #endif

--- a/OptrixOS-Kernel/src/disk.c
+++ b/OptrixOS-Kernel/src/disk.c
@@ -1,0 +1,33 @@
+#include "disk.h"
+#include "ports.h"
+#include <stddef.h>
+
+static void io_wait(void){
+    for(int i=0;i<1000;i++) { __asm__("nop"); }
+}
+
+static void ata_wait(void){
+    while(inb(0x1F7) & 0x80) { io_wait(); }
+}
+
+void ata_read_sectors(uint32_t lba, uint8_t count, uint8_t *buffer){
+    ata_wait();
+    outb(0x1F6, 0xE0 | ((lba>>24)&0xF));
+    outb(0x1F2, count);
+    outb(0x1F3, (uint8_t)lba);
+    outb(0x1F4, (uint8_t)(lba>>8));
+    outb(0x1F5, (uint8_t)(lba>>16));
+    outb(0x1F7, 0x20); // READ SECTOR
+    for(uint8_t s=0; s<count; s++) {
+        ata_wait();
+        for(int i=0;i<256;i++) {
+            uint16_t data = inw(0x1F0);
+            buffer[s*512 + i*2] = data & 0xFF;
+            buffer[s*512 + i*2 + 1] = data >> 8;
+        }
+    }
+}
+
+void ata_read_sector(uint32_t lba, uint8_t *buffer){
+    ata_read_sectors(lba, 1, buffer);
+}

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -1,151 +1,34 @@
 #include "fs.h"
-#include "resources.h"
+#include "disk.h"
+#include "build_params.h"
 #include <stddef.h>
+#include <stdint.h>
 
-static int streq(const char* a, const char* b) {
-    while(*a && *b) {
-        if(*a != *b) return 0;
-        a++; b++;
-    }
-    return *a == *b;
-}
+static int streq(const char*a,const char*b){while(*a&&*b){if(*a!=*b)return 0;a++;b++;}return *a==*b;}
 
 #define MAX_ROOT_ENTRIES 20
-static fs_entry root_entries[MAX_ROOT_ENTRIES];
-static int root_count = 0;
-
-#define MAX_BIN_ENTRIES 5
-static fs_entry bin_entries[MAX_BIN_ENTRIES];
-static int bin_count = 0;
-
-#define MAX_DOC_ENTRIES 5
-static fs_entry docs_entries[MAX_DOC_ENTRIES];
-static int docs_count = 0;
-
-/* entries for /desktop */
-#define MAX_DESKTOP_ENTRIES 20
-static fs_entry desktop_entries[MAX_DESKTOP_ENTRIES];
-static int desktop_count = 0;
-
-static fs_entry root_dir = {"/", 1, NULL, root_entries, 0, ""};
-
 #define MAX_EXTRA_DIRS 20
 #define MAX_EXTRA_DIR_ENTRIES 20
+static fs_entry root_entries[MAX_ROOT_ENTRIES];
 static fs_entry extra_dir_entries[MAX_EXTRA_DIRS][MAX_EXTRA_DIR_ENTRIES];
-static int extra_dir_used = 0;
+static int extra_dir_used=0;
+static fs_entry root_dir={"/",1,NULL,root_entries,0,""};
 
-fs_entry* fs_get_root(void) {
-    return &root_dir;
-}
+fs_entry* fs_get_root(void){return &root_dir;}
 
-void fs_init(void) {
-    root_count = 0;
-    bin_count = 0;
-    docs_count = 0;
-    desktop_count = 0;
+fs_entry* fs_find_subdir(fs_entry*dir,const char*name){for(int i=0;i<dir->child_count;i++)if(dir->children[i].is_dir&&streq(dir->children[i].name,name))return &dir->children[i];return 0;}
+fs_entry* fs_find_entry(fs_entry*dir,const char*name){for(int i=0;i<dir->child_count;i++)if(streq(dir->children[i].name,name))return &dir->children[i];return 0;}
 
-    /* setup /bin directory */
-    fs_entry bin = {"bin", 1, &root_dir, bin_entries, 0, ""};
-    root_entries[root_count++] = bin;
+fs_entry* fs_create_dir(fs_entry*dir,const char*name){int limit=(dir==&root_dir)?MAX_ROOT_ENTRIES:MAX_EXTRA_DIR_ENTRIES;if(dir->child_count>=limit||extra_dir_used>=MAX_EXTRA_DIRS)return 0;fs_entry*e=&dir->children[dir->child_count++];int i=0;for(;i<31&&name[i];i++)e->name[i]=name[i];e->name[i]=0;e->is_dir=1;e->parent=dir;e->children=extra_dir_entries[extra_dir_used++];e->child_count=0;return e;}
+fs_entry* fs_create_file(fs_entry*dir,const char*name){int limit=(dir==&root_dir)?MAX_ROOT_ENTRIES:MAX_EXTRA_DIR_ENTRIES;if(dir->child_count>=limit)return 0;fs_entry*e=&dir->children[dir->child_count++];int i=0;for(;i<31&&name[i];i++)e->name[i]=name[i];e->name[i]=0;e->is_dir=0;e->parent=dir;e->children=NULL;e->child_count=0;e->content[0]=0;return e;}
 
-    /* setup /docs directory */
-    fs_entry docs = {"docs", 1, &root_dir, docs_entries, 0, ""};
-    root_entries[root_count++] = docs;
+int fs_delete_entry(fs_entry*dir,const char*name){for(int i=0;i<dir->child_count;i++)if(streq(dir->children[i].name,name)){for(int j=i;j<dir->child_count-1;j++)dir->children[j]=dir->children[j+1];dir->child_count--;return 1;}return 0;}
 
-    /* setup /desktop directory */
-    fs_entry desktop = {"desktop", 1, &root_dir, desktop_entries, 0, ""};
-    root_entries[root_count++] = desktop;
-    fs_entry *desktop_ptr = &root_entries[root_count-1];
+void fs_write_file(fs_entry*f,const char*text){if(!f||f->is_dir)return;int k=0;while(text[k]&&k<255){f->content[k]=text[k];k++;}f->content[k]=0;}
+const char* fs_read_file(fs_entry*f){if(!f||f->is_dir)return "";return f->content;}
 
-    /* simple readme */
-    fs_entry readme = {"readme.txt", 0, &root_dir, NULL, 0, "Welcome to OptrixOS"};
-    root_entries[root_count++] = readme;
+static fs_entry* ensure_dir(const char*path){fs_entry*dir=&root_dir;char name[32];int idx=0;for(int i=0;path[i];i++){if(path[i]=='/') {if(idx){name[idx]=0;fs_entry*sub=fs_find_subdir(dir,name);if(!sub)sub=fs_create_dir(dir,name);dir=sub;idx=0;}}else if(idx<31){name[idx++]=path[i];}}if(idx){name[idx]=0;fs_entry*sub=fs_find_subdir(dir,name);if(!sub)sub=fs_create_dir(dir,name);dir=sub;}return dir;}
 
-    /* /desktop/terminal.opt executable */
-    fs_entry term = {"terminal.opt", 0, desktop_ptr, NULL, 0, ""};
-    desktop_entries[desktop_count++] = term;
-    desktop_ptr->child_count = desktop_count;
+static void create_file_with_path(const char*path,const char*data){const char*slash=NULL;for(int i=0;path[i];i++)if(path[i]=='/')slash=path+i;fs_entry*dir=&root_dir;const char*name=path;char parent[64];if(slash){int len=slash-path;for(int i=0;i<len&&i<63;i++)parent[i]=path[i];parent[len]=0;dir=ensure_dir(parent);name=slash+1;}fs_entry*f=fs_create_file(dir,name);if(f)fs_write_file(f,data);} 
 
-    root_dir.child_count = root_count;
-
-    /* add compiled-in resource files to root */
-    for(int i=0; i<resource_files_count && root_dir.child_count < MAX_ROOT_ENTRIES; i++) {
-        fs_entry* f = fs_create_file(&root_dir, resource_files[i].name);
-        if(f)
-            fs_write_file(f, resource_files[i].data);
-    }
-}
-
-fs_entry* fs_find_subdir(fs_entry* dir, const char* name) {
-    for(int i=0; i<dir->child_count; i++)
-        if(dir->children[i].is_dir && name && dir->children[i].name &&
-           streq(dir->children[i].name, name))
-            return (fs_entry*)&dir->children[i];
-    return 0;
-}
-
-fs_entry* fs_find_entry(fs_entry* dir, const char* name) {
-    for(int i=0; i<dir->child_count; i++)
-        if(name && streq(dir->children[i].name, name))
-            return &dir->children[i];
-    return 0;
-}
-
-fs_entry* fs_create_file(fs_entry* dir, const char* name) {
-    int limit = (dir == &root_dir) ? MAX_ROOT_ENTRIES : MAX_EXTRA_DIR_ENTRIES;
-    if(dir->child_count >= limit) return 0;
-    fs_entry* e = &dir->children[dir->child_count++];
-    for(int i=0;i<32;i++){e->name[i]=0;}
-    int idx=0; while(name[idx] && idx<31){ e->name[idx]=name[idx]; idx++; }
-    e->name[idx]='\0';
-    e->is_dir = 0;
-    e->parent = dir;
-    e->children = NULL;
-    e->child_count = 0;
-    e->content[0]='\0';
-    return e;
-}
-
-fs_entry* fs_create_dir(fs_entry* dir, const char* name) {
-    int limit = (dir == &root_dir) ? MAX_ROOT_ENTRIES : MAX_EXTRA_DIR_ENTRIES;
-    if(dir->child_count >= limit) return 0;
-    if(extra_dir_used >= MAX_EXTRA_DIRS) return 0;
-    fs_entry* e = &dir->children[dir->child_count++];
-    for(int i=0;i<32;i++){e->name[i]=0;}
-    int idx=0; while(name[idx] && idx<31){ e->name[idx]=name[idx]; idx++; }
-    e->name[idx]='\0';
-    e->is_dir = 1;
-    e->parent = dir;
-    e->children = extra_dir_entries[extra_dir_used];
-    e->child_count = 0;
-    e->content[0]='\0';
-    extra_dir_used++;
-    return e;
-}
-
-int fs_delete_entry(fs_entry* dir, const char* name) {
-    for(int i=0;i<dir->child_count;i++) {
-        if(streq(dir->children[i].name,name)) {
-            for(int j=i;j<dir->child_count-1;j++)
-                dir->children[j]=dir->children[j+1];
-            dir->child_count--;
-            return 1;
-        }
-    }
-    return 0;
-}
-
-void fs_write_file(fs_entry* file, const char* text) {
-    if(!file || file->is_dir) return;
-    int k = 0;
-    while(text[k] && k < 255) {
-        file->content[k] = text[k];
-        k++;
-    }
-    file->content[k] = '\0';
-}
-
-const char* fs_read_file(fs_entry* file) {
-    if(!file || file->is_dir) return "";
-    return file->content;
-}
+void fs_init(void){root_dir.child_count=0;extra_dir_used=0;uint32_t total=FS_SECTORS;uint8_t*buf=(uint8_t*)0x80000;for(uint32_t i=0;i<total;i++)ata_read_sector(FS_START_SECTOR+i,buf+i*512);uint32_t magic=*(uint32_t*)buf;if(magic!=0x46534631)return;uint32_t count=*(uint32_t*)(buf+4);size_t off=8;for(uint32_t e=0;e<count;e++){uint8_t type=buf[off++];uint8_t plen=buf[off++];char path[64];for(int i=0;i<plen&&i<63;i++)path[i]=buf[off++];path[plen]=0;if(type){ensure_dir(path);}else{uint32_t size=*(uint32_t*)(buf+off);off+=4;char*text=(char*)(buf+off);off+=size;if(size>255){size=255;}char tmp[256];for(uint32_t i=0;i<size;i++)tmp[i]=text[i];tmp[size]=0;create_file_with_path(path,tmp);}}}


### PR DESCRIPTION
## Summary
- add minimal ATA disk driver and port I/O helpers
- create fs image at build time and embed it in disk image
- load filesystem data from disk on boot instead of using hardcoded C data
- adjust build script to generate fs image and pass sector info

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_685327893b18832fb89361dd622aa661