### PR TITLE
Implement simple initrd loading

### DIFF
--- a/OptrixOS-Kernel/asm/kernel.asm
+++ b/OptrixOS-Kernel/asm/kernel.asm
@@ -2,9 +2,19 @@ BITS 32
 
 extern kernel_main
 
+extern initrd_addr
+extern initrd_size
+
 global start
 start:
+    mov [initrd_addr], ebx
+    mov [initrd_size], ecx
     call kernel_main
 .halt:
     hlt
     jmp .halt
+
+section .bss
+    align 4
+initrd_addr: resd 1
+initrd_size: resd 1

--- a/OptrixOS-Kernel/include/fs.h
+++ b/OptrixOS-Kernel/include/fs.h
@@ -32,4 +32,6 @@ fs_entry* fs_resolve_path(fs_entry* start, const char* path);
 /* Construct the full path for an entry. */
 void fs_get_path(fs_entry* entry, char* out, int max);
 
+void fs_load_initrd(const unsigned char* data, unsigned int size);
+
 #endif

--- a/OptrixOS-Kernel/include/resources.h
+++ b/OptrixOS-Kernel/include/resources.h
@@ -1,6 +1,0 @@
-#ifndef RESOURCES_H
-#define RESOURCES_H
-typedef struct { const char* name; const char* data; } resource_file;
-extern const int resource_files_count;
-extern const resource_file resource_files[];
-#endif

--- a/OptrixOS-Kernel/src/kernel_main.c
+++ b/OptrixOS-Kernel/src/kernel_main.c
@@ -2,15 +2,21 @@
 #include "terminal.h"
 #include "driver.h"
 #include "mem.h"
+#include "fs.h"
 
 /* simple heap placed at 0x200000 for illustration */
 #define HEAP_BASE ((unsigned char*)0x200000)
 #define HEAP_SIZE (64*1024)
 
+extern unsigned int initrd_addr;
+extern unsigned int initrd_size;
+
 void kernel_main(void) {
     screen_init();
     mem_init(HEAP_BASE, HEAP_SIZE);
     driver_init_all();
+
+    fs_load_initrd((const unsigned char*)initrd_addr, initrd_size);
 
     terminal_init();
     terminal_run();

--- a/OptrixOS-Kernel/src/resources.c
+++ b/OptrixOS-Kernel/src/resources.c
@@ -1,6 +1,0 @@
-#include "resources.h"
-const resource_file resource_files[] = {
-    {"welcome.txt", "Welcome to OptrixOS!\nEnjoy your stay.\n"},
-    {"logo.txt", "  ____        _   _      ____  _____ \n / __ \\      | | | |    / __ \\|  __ \\\n| |  | |_ __ | |_| |_  | |  | | |__) |\n| |  | | '_ \\| __| __| | |  | |  ___/\n| |__| | | | | |_| |_  | |__| | |    \n \\____/|_| |_|\\__|\\__|  \\____/|_|    \n"},
-};
-const int resource_files_count = 2;

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ behaviour of the historic `fsboot` loader. When executed it:
 - Sets the classic 80x25 text mode and jumps directly to the kernel.
 
 The kernel runs entirely in text mode and provides a small shell interface.
+Files are now loaded from a tiny initrd image rather than being compiled into
+the kernel. The build script packages everything inside `OptrixOS-Kernel/resources`
+into `initrd.img` which is loaded by the bootloader before jumping to the kernel.
 
 Use `python3 setup_bootloader.py` to assemble and link the boot files. The
 script builds a small custom kernel located in `OptrixOS-Kernel/` and produces


### PR DESCRIPTION
## Summary
- support loading an initrd image from disk
- parse files from initrd during boot
- pass initrd address and size via registers
- rebuild bootloader and kernel with new Python build script
- update documentation

## Testing
- `python3 setup_bootloader.py --skip-iso`

------
https://chatgpt.com/codex/tasks/task_e_685332f76fe4832f8bc62a8d127bab30