### PR TITLE
Enhance FS path handling and build script

### DIFF
--- a/OptrixOS-Kernel/include/fs.h
+++ b/OptrixOS-Kernel/include/fs.h
@@ -25,4 +25,11 @@ void fs_init(void);
 fs_entry* fs_get_root(void);
 fs_entry* fs_find_subdir(fs_entry* dir, const char* name);
 
+/* Resolve a path starting at the given directory. Handles '.', '..' and
+   absolute paths beginning with '/'. Returns NULL on failure. */
+fs_entry* fs_resolve(fs_entry* start, const char* path);
+
+/* Build the full path of an entry into the provided buffer. */
+void fs_get_path(fs_entry* entry, char* out, int max_len);
+
 #endif

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -77,8 +77,10 @@ def assemble(src, out, fmt="bin", defines=None):
     run(cmd)
     tmp_files.append(out)
 
+EXTRA_CFLAGS = os.environ.get("EXTRA_CFLAGS", "").split()
+
 def compile_c(src, out):
-    run([
+    cmd = [
         CC,
         "-ffreestanding",
         "-fno-pie",
@@ -88,7 +90,8 @@ def compile_c(src, out):
         "-o", out,
         "-Iinclude",
         "-IOptrixOS-Kernel/include"
-    ])
+    ] + EXTRA_CFLAGS
+    run(cmd)
     tmp_files.append(out)
 
 def roundup(x, align):


### PR DESCRIPTION
## Summary
- add path resolution helpers to the simple filesystem
- support displaying full paths and changing directory using paths
- use new fs functions in terminal for cd/cat/banner and during init
- allow extra compiler flags via `EXTRA_CFLAGS` env var in build script

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs.exe not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533519c3c4832f8b90108437a79319