### PR TITLE
Include default resources and improve build script

### DIFF
--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -69,7 +69,7 @@ void fs_init(const void* initrd_start, unsigned int initrd_size) {
 
     root_dir.child_count = root_count;
 
-    /* load files from initrd */
+    /* load files from initrd if provided */
     if(initrd_start && initrd_size >= 4) {
         const uint8_t* ptr = (const uint8_t*)initrd_start;
         uint32_t count = *(const uint32_t*)ptr; ptr += 4;
@@ -91,6 +91,19 @@ void fs_init(const void* initrd_start, unsigned int initrd_size) {
             }
             ptr += sz;
         }
+    } else {
+        /* fallback files when no initrd is available */
+        fs_entry* f = fs_create_file(&root_dir, "logo.txt");
+        if(f) fs_write_file(f,
+            "  ____        _   _      ____  _____\n"
+            " / __ \\      | | | |    / __ \\|  __ \\n"
+            "| |  | |_ __ | |_| |_  | |  | | |__) |\n"
+            "| |  | | '_ \\| __| __| | |  | |  ___/\n"
+            "| |__| | | | | |_| |_  | |__| | |\n"
+            " \\____/|_| |_|\\__|\\__|  \\____/|_|");
+
+        f = fs_create_file(&root_dir, "welcome.txt");
+        if(f) fs_write_file(f, "Welcome to OptrixOS!\nEnjoy your stay.\n");
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ behaviour of the historic `fsboot` loader. When executed it:
 
 The kernel runs entirely in text mode and provides a small shell interface.
 
-Use `python3 setup_bootloader.py` to assemble and link the boot files. The
-script builds a small custom kernel located in `OptrixOS-Kernel/` and produces
-`OptrixOS-kernel.bin`. A cross compiler (`i686-linux-gnu-gcc`/`ld`) is preferred,
-but if it is not installed the script will fall back to the system `gcc` and
-`ld` with `-m32`.
+Use `python3 setup_bootloader.py` to assemble and link the boot files. The script
+automatically packages everything under `OptrixOS-Kernel/resources` into an
+initrd so these files appear in the OS root directory. A cross compiler
+(`i686-linux-gnu-gcc`/`ld`) is preferred, but if it is not installed the script
+will fall back to the system `gcc` and `ld` with `-m32`.
 
 
 
@@ -35,8 +35,9 @@ Build the bootable image with:
 python3 setup_bootloader.py
 ```
 
-If `mkisofs` is available an ISO named `OptrixOS.iso` is created. Otherwise the
-script outputs `disk.img` which can be run with:
+If `mkisofs` is available an ISO named `OptrixOS.iso` is created. When
+`mkisofs` is not present the build script automatically skips ISO creation and
+outputs `disk.img`, which can be run with:
 
 ```bash
 qemu-system-x86_64 -hda disk.img

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -263,9 +263,9 @@ def copy_tree_to_iso(tmp_iso_dir, proj_root):
 def make_iso_with_tree(tmp_iso_dir, iso_out):
     print(f"Creating ISO using: {MKISOFS_EXE}")
     print(f"ISO should be written to: {iso_out}")
-    if not os.path.isfile(MKISOFS_EXE):
-        print(f"Error: mkisofs.exe not found at {MKISOFS_EXE}!")
-        sys.exit(1)
+    if not shutil.which(MKISOFS_EXE) and not os.path.isfile(MKISOFS_EXE):
+        print(f"Warning: mkisofs not found (looked for {MKISOFS_EXE}). Skipping ISO creation.")
+        return
     if os.path.exists(iso_out):
         os.remove(iso_out)
     cmd = [


### PR DESCRIPTION
## Summary
- embed fallback `logo.txt` and `welcome.txt` if no initrd is loaded
- skip ISO creation when `mkisofs` is missing
- document automatic resource packaging and mkisofs fallback

## Testing
- `python3 -m py_compile setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_6853397df474832fbc735a221fafff1c