### PR TITLE
Fix build system and extend in-memory FS

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -1,29 +1,20 @@
 CFLAGS=-ffreestanding -fno-pie -fno-pic -m32 -Iinclude
-	
-all: disk.img
-	
-bootloader.bin: asm/bootloader.asm
-	@nasm -f bin $< -o $@
-	
-kernel.bin: asm/kernel.asm asm/ports.asm src/screen.o src/keyboard.o src/terminal.o src/fs.o src/driver.o src/mem.o src/kernel_main.o
-	@nasm -f elf32 asm/kernel.asm -o kernel_asm.o
-	@nasm -f elf32 asm/ports.asm -o ports.o
-	@gcc $(CFLAGS) -c src/screen.c -o src/screen.o
-	@gcc $(CFLAGS) -c src/keyboard.c -o src/keyboard.o
-	@gcc $(CFLAGS) -c src/terminal.c -o src/terminal.o
-	@gcc $(CFLAGS) -c src/fs.c -o src/fs.o
-	@gcc $(CFLAGS) -c src/driver.c -o src/driver.o
-	@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
-	@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
-	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
-	src/screen.o src/keyboard.o src/terminal.o src/fs.o \
-	src/driver.o src/mem.o src/kernel_main.o --oformat binary -o $@
-	
-disk.img: bootloader.bin kernel.bin
-	@cat bootloader.bin kernel.bin > $@
-	
-run: disk.img
-	@qemu-system-i386 -drive format=raw,file=disk.img
-	
+
+# This Makefile simply forwards to the Python build script so that
+# users building via `make` also get the initrd and resources embedded.
+
+.PHONY: all iso run clean
+
+all: iso
+
+# Build the bootable image and ISO using the helper script
+iso:
+	python3 ../setup_bootloader.py
+
+# Run the resulting ISO with QEMU
+run: iso
+	qemu-system-i386 -cdrom ../OptrixOS.iso
+
 clean:
-	@rm -f *.bin *.o disk.img src/*.o kernel_asm.o
+	rm -rf _build_obj bootloader.bin OptrixOS-kernel.bin \
+	OptrixOS-kernel.elf disk.img ../OptrixOS.iso

--- a/OptrixOS-Kernel/include/fs.h
+++ b/OptrixOS-Kernel/include/fs.h
@@ -7,7 +7,8 @@ typedef struct fs_entry {
     struct fs_entry* parent;
     struct fs_entry* children;
     int child_count;
-    char content[256];
+    char* content;
+    unsigned int size;
 } fs_entry;
 
 fs_entry* fs_find_entry(fs_entry* dir, const char* name);
@@ -15,8 +16,12 @@ fs_entry* fs_create_file(fs_entry* dir, const char* name);
 fs_entry* fs_create_dir(fs_entry* dir, const char* name);
 int fs_delete_entry(fs_entry* dir, const char* name);
 
-/* Write text content to a file entry. Text is truncated to 255 chars. */
+/* Write text content to a file entry. The string is copied into dynamic
+   memory allocated from the simple heap. */
 void fs_write_file(fs_entry* file, const char* text);
+
+/* Write raw data of specified length. */
+void fs_write_file_len(fs_entry* file, const char* data, unsigned int len);
 
 /* Read the content of a file entry. Returns empty string for directories */
 const char* fs_read_file(fs_entry* file);

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ behaviour of the historic `fsboot` loader. When executed it:
 
 The kernel runs entirely in text mode and provides a small shell interface.
 
-Use `python3 setup_bootloader.py` to assemble and link the boot files. The script
+Use `python3 setup_bootloader.py` (or simply run `make` inside
+`OptrixOS-Kernel`) to assemble and link the boot files. The script
 automatically packages everything under `OptrixOS-Kernel/resources` into an
 initrd so these files appear in the OS root directory. A cross compiler
 (`i686-linux-gnu-gcc`/`ld`) is preferred, but if it is not installed the script


### PR DESCRIPTION
## Summary
- forward to Python build script from Makefile so `make` embeds resources
- document that `make` also runs the build script
- expand `fs_entry` to use dynamic buffers
- load initrd files using new helper function

## Testing
- `python3 setup_bootloader.py`


------
https://chatgpt.com/codex/tasks/task_e_68533ca038f0832f93af167aaf3c2844