### PR TITLE
Improve ISO build checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Build the bootable image with:
 python3 setup_bootloader.py
 ```
 
-If `mkisofs` is available an ISO named `OptrixOS.iso` is created. Otherwise the
-script outputs `disk.img` which can be run with:
+If `mkisofs` (or the compatible `genisoimage`) is available an ISO named
+`OptrixOS.iso` is created. Otherwise the script outputs `disk.img` which can be
+run with:
 
 ```bash
 qemu-system-x86_64 -hda disk.img

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -28,7 +28,10 @@ if not shutil.which(OBJDUMP):
 CDRTOOLS_DIR = os.environ.get("CDRTOOLS_DIR") or r"C:\\Program Files (x86)\\cdrtools"
 MKISOFS_EXE = os.environ.get("MKISOFS") or os.path.join(CDRTOOLS_DIR, "mkisofs.exe")
 if not os.path.isfile(MKISOFS_EXE):
-    MKISOFS_EXE = shutil.which("mkisofs") or "mkisofs"
+    # Check both mkisofs and genisoimage which provides mkisofs on many systems
+    MKISOFS_EXE = (shutil.which("mkisofs") or
+                   shutil.which("genisoimage") or
+                   "mkisofs")
 
 # Only build sources inside the kernel directory
 KERNEL_PROJECT_ROOT = "OptrixOS-Kernel"


### PR DESCRIPTION
## Summary
- enhance setup script to automatically use genisoimage
- clarify README about mkisofs/genisoimage

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68534632d2ac832f81f7cd3a26fc7939