### PR TITLE
Fix ISO creation with large disk images

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ script outputs `disk.img` which can be run with:
 qemu-system-x86_64 -hda disk.img
 ```
 
+The ISO build now uses the `-no-emul-boot` option so `disk.img` can be
+any size. This removes the old floppy size limits and allows larger
+filesystems to be included in the image.
+
 ## Built-in terminal
 
 After boot the machine displays a plain text console. No graphics or windowing

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -266,6 +266,9 @@ def make_iso_with_tree(tmp_iso_dir, iso_out):
         "-quiet",
         "-o", iso_out,
         "-b", "disk.img",
+        "-no-emul-boot",
+        "-boot-load-size", str((os.path.getsize(os.path.join(tmp_iso_dir, "disk.img")) + 511) // 512),
+        "-boot-info-table",
         "-R", "-J", "-l",
         tmp_iso_dir
     ]


### PR DESCRIPTION
## Summary
- allow `mkisofs` to generate an ISO for any disk image size by using `-no-emul-boot`
- document the new ISO build behaviour in README

## Testing
- `python3 -m py_compile setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68534edb6810832fa118087abf79c734