### PR TITLE
Fix mkisofs boot image size

### DIFF
--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -103,9 +103,9 @@ def make_dynamic_img(boot_bin, kernel_bin, img_out):
     kern = open(kernel_bin, "rb").read()
     total = 512 + len(kern)
     min_size = 1474560  # 1.44MB
-    img_size = roundup(total, 512)
+    img_size = roundup(total, 2048)
     if img_size < min_size:
-        img_size = min_size
+        img_size = roundup(min_size, 2048)
     with open(img_out, "wb") as img:
         img.write(boot)
         img.write(kern)


### PR DESCRIPTION
## Summary
- align disk image to 2048 bytes before creating ISO

## Testing
- `sudo apt-get update`
- `sudo apt-get install -y genisoimage`
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68535009f338832f85571efd7b2380b1