### PR TITLE
Fix ISO build for dynamic disk images

### DIFF
--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -103,7 +103,10 @@ def make_dynamic_img(boot_bin, kernel_bin, img_out):
     kern = open(kernel_bin, "rb").read()
     total = 512 + len(kern)
     min_size = 1474560  # 1.44MB
-    img_size = roundup(total, 512)
+    # mkisofs requires the boot image size to be a multiple of 2048 bytes when
+    # using -no-emul-boot.  Round the disk image up to 2048 bytes to avoid
+    # "boot image has not an allowable size" errors.
+    img_size = roundup(total, 2048)
     if img_size < min_size:
         img_size = min_size
     with open(img_out, "wb") as img:
@@ -267,7 +270,11 @@ def make_iso_with_tree(tmp_iso_dir, iso_out):
         "-o", iso_out,
         "-b", "disk.img",
         "-no-emul-boot",
-        "-boot-load-size", str((os.path.getsize(os.path.join(tmp_iso_dir, "disk.img")) + 511) // 512),
+        # boot-load-size is specified in 512 byte sectors, but needs to be a
+        # multiple of 4 (2048 bytes). Round up accordingly so mkisofs accepts
+        # the image size.
+        "-boot-load-size",
+        str(roundup(os.path.getsize(os.path.join(tmp_iso_dir, "disk.img")), 2048) // 512),
         "-boot-info-table",
         "-R", "-J", "-l",
         tmp_iso_dir


### PR DESCRIPTION
## Summary
- ensure dynamic disk images are rounded to 2048 bytes
- round boot-load-size in mkisofs call to a multiple of 2048

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68535184fb10832f9bd268a3a2c49668