### PR TITLE
Add ATA driver and bootloader fixes

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -12,6 +12,8 @@ start:
     mov es, ax
     mov ss, ax
     mov sp, 0x7C00
+    ; store BIOS-provided boot drive number
+    mov [BOOT_DRIVE], dl
 
     ; Set 80x25 text mode
     mov ax, 0x0003

--- a/OptrixOS-Kernel/asm/ports.asm
+++ b/OptrixOS-Kernel/asm/ports.asm
@@ -2,6 +2,8 @@
 
 GLOBAL inb
 GLOBAL outb
+GLOBAL inw
+GLOBAL outw
 
 inb:
     mov edx, [esp+4]
@@ -13,4 +15,16 @@ outb:
     mov edx, [esp+4]
     mov al, [esp+8]
     out dx, al
+    ret
+
+inw:
+    mov edx, [esp+4]
+    in ax, dx
+    movzx eax, ax
+    ret
+
+outw:
+    mov edx, [esp+4]
+    mov ax, [esp+8]
+    out dx, ax
     ret

--- a/OptrixOS-Kernel/include/ata.h
+++ b/OptrixOS-Kernel/include/ata.h
@@ -1,0 +1,7 @@
+#ifndef ATA_H
+#define ATA_H
+#include <stdint.h>
+
+int ata_read_sectors(uint32_t lba, uint8_t count, void* buffer);
+
+#endif

--- a/OptrixOS-Kernel/include/fs.h
+++ b/OptrixOS-Kernel/include/fs.h
@@ -1,5 +1,6 @@
 #ifndef FS_H
 #define FS_H
+#include <stdint.h>
 
 typedef struct fs_entry {
     char* name;
@@ -24,5 +25,6 @@ const char* fs_read_file(fs_entry* file);
 void fs_init(void);
 fs_entry* fs_get_root(void);
 fs_entry* fs_find_subdir(fs_entry* dir, const char* name);
+void fs_load_sector_file(uint32_t lba, uint8_t sectors, const char* name);
 
 #endif

--- a/OptrixOS-Kernel/include/ports.h
+++ b/OptrixOS-Kernel/include/ports.h
@@ -3,4 +3,6 @@
 #include <stdint.h>
 uint8_t inb(uint16_t port);
 void outb(uint16_t port, uint8_t data);
+uint16_t inw(uint16_t port);
+void outw(uint16_t port, uint16_t data);
 #endif

--- a/OptrixOS-Kernel/src/ata.c
+++ b/OptrixOS-Kernel/src/ata.c
@@ -1,0 +1,31 @@
+#include "ata.h"
+#include "ports.h"
+
+static int ata_wait(void) {
+    for(int i=0;i<100000;i++) {
+        uint8_t status = inb(0x1F7);
+        if(!(status & 0x80) && (status & 0x08))
+            return 0;
+    }
+    return -1;
+}
+
+int ata_read_sectors(uint32_t lba, uint8_t count, void* buffer) {
+    uint16_t* buf = (uint16_t*)buffer;
+    outb(0x1F6, 0xE0 | ((lba >> 24) & 0x0F));
+    outb(0x1F2, count);
+    outb(0x1F3, (uint8_t)lba);
+    outb(0x1F4, (uint8_t)(lba >> 8));
+    outb(0x1F5, (uint8_t)(lba >> 16));
+    outb(0x1F7, 0x20);
+
+    for(int s=0; s<count; s++) {
+        if(ata_wait())
+            return -1;
+        for(int i=0;i<256;i++) {
+            buf[i] = inw(0x1F0);
+        }
+        buf += 256;
+    }
+    return 0;
+}

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -1,6 +1,7 @@
 #include "fs.h"
 #include "mem.h"
 #include "resources.h"
+#include "ata.h"
 #include <stddef.h>
 
 static fs_entry root_dir;
@@ -110,4 +111,12 @@ void fs_init(void){
         fs_entry* f=fs_create_file(resources,resource_files[i].name);
         if(f) fs_write_file(f,resource_files[i].data);
     }
+}
+
+void fs_load_sector_file(uint32_t lba, uint8_t sectors, const char* name){
+    char* buf = mem_alloc(sectors * 512);
+    if(!buf) return;
+    if(ata_read_sectors(lba, sectors, buf) != 0) return;
+    fs_entry* f = fs_create_file(&root_dir, name);
+    if(f) fs_write_file(f, buf);
 }

--- a/OptrixOS-Kernel/src/kernel_main.c
+++ b/OptrixOS-Kernel/src/kernel_main.c
@@ -2,6 +2,7 @@
 #include "terminal.h"
 #include "driver.h"
 #include "mem.h"
+#include "fs.h"
 
 /* simple heap placed at 0x200000 for illustration */
 #define HEAP_BASE ((unsigned char*)0x200000)
@@ -11,6 +12,8 @@ void kernel_main(void) {
     screen_init();
     mem_init(HEAP_BASE, HEAP_SIZE);
     driver_init_all();
+
+    fs_load_sector_file(1, 1, "disksector.bin");
 
     terminal_init();
     terminal_run();

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -103,10 +103,8 @@ def make_dynamic_img(boot_bin, kernel_bin, img_out):
     kern = open(kernel_bin, "rb").read()
     total = 512 + len(kern)
     min_size = 1474560  # 1.44MB
-    # mkisofs requires the boot image size to be a multiple of 2048 bytes when
-    # using -no-emul-boot.  Round the disk image up to 2048 bytes to avoid
-    # "boot image has not an allowable size" errors.
-    img_size = roundup(total, 2048)
+    # Round to 512 byte sectors for floppy emulation
+    img_size = roundup(total, 512)
     if img_size < min_size:
         img_size = min_size
     with open(img_out, "wb") as img:
@@ -269,13 +267,6 @@ def make_iso_with_tree(tmp_iso_dir, iso_out):
         "-quiet",
         "-o", iso_out,
         "-b", "disk.img",
-        "-no-emul-boot",
-        # boot-load-size is specified in 512 byte sectors, but needs to be a
-        # multiple of 4 (2048 bytes). Round up accordingly so mkisofs accepts
-        # the image size.
-        "-boot-load-size",
-        str(roundup(os.path.getsize(os.path.join(tmp_iso_dir, "disk.img")), 2048) // 512),
-        "-boot-info-table",
         "-R", "-J", "-l",
         tmp_iso_dir
     ]


### PR DESCRIPTION
## Summary
- fix bootloader to save BIOS drive number
- add inw/outw helpers and new ATA disk driver
- expose file-loading helper in filesystem
- load a disk sector in kernel_main
- build floppy-style ISO without `-no-emul-boot`

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_685353b86f68832f9576c135ebd78e18