### PR TITLE
Add basic ISO parsing

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -12,12 +12,13 @@ kernel.bin: asm/kernel.asm asm/ports.asm src/screen.o src/keyboard.o src/termina
 	@gcc $(CFLAGS) -c src/keyboard.c -o src/keyboard.o
 	@gcc $(CFLAGS) -c src/terminal.c -o src/terminal.o
 	@gcc $(CFLAGS) -c src/fs.c -o src/fs.o
+	@gcc $(CFLAGS) -c src/iso9660.c -o src/iso9660.o
 	@gcc $(CFLAGS) -c src/driver.c -o src/driver.o
 	@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
 	@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
 	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
-	src/screen.o src/keyboard.o src/terminal.o src/fs.o \
-	src/driver.o src/mem.o src/kernel_main.o --oformat binary -o $@
+        src/screen.o src/keyboard.o src/terminal.o src/fs.o \
+        src/iso9660.o src/driver.o src/mem.o src/kernel_main.o --oformat binary -o $@
 	
 disk.img: bootloader.bin kernel.bin
 	@cat bootloader.bin kernel.bin > $@

--- a/OptrixOS-Kernel/include/iso9660.h
+++ b/OptrixOS-Kernel/include/iso9660.h
@@ -1,0 +1,6 @@
+#ifndef ISO9660_H
+#define ISO9660_H
+
+void iso_populate_fs(void);
+
+#endif

--- a/OptrixOS-Kernel/src/iso9660.c
+++ b/OptrixOS-Kernel/src/iso9660.c
@@ -1,0 +1,75 @@
+#include "iso9660.h"
+#include "ata.h"
+#include "fs.h"
+#include "mem.h"
+#include <stdint.h>
+
+/* Read 2048 byte ISO sector using 512 byte ATA sectors */
+static int iso_read_sector2048(uint32_t sector, void* buffer){
+    uint8_t* buf = (uint8_t*)buffer;
+    for(int i=0;i<4;i++){
+        if(ata_read_sectors(sector*4 + i, 1, buf + i*512) != 0)
+            return -1;
+    }
+    return 0;
+}
+
+static uint32_t read_le32(const uint8_t* p){
+    return p[0] | (p[1]<<8) | (p[2]<<16) | (p[3]<<24);
+}
+
+void iso_populate_fs(void){
+    uint8_t pvd[2048];
+    if(iso_read_sector2048(16, pvd) != 0)
+        return;
+    if(pvd[0] != 1 || pvd[1] != 'C' || pvd[2] != 'D' || pvd[3] != '0' || pvd[4] != '0' || pvd[5] != '1')
+        return;
+    const uint8_t* root_rec = pvd + 156;
+    uint32_t root_sector = read_le32(root_rec + 2);
+    uint32_t root_size = read_le32(root_rec + 10);
+    uint8_t* dir = mem_alloc(root_size);
+    if(!dir) return;
+    for(uint32_t off=0; off<root_size; off+=2048){
+        if(iso_read_sector2048(root_sector + off/2048, dir + off) != 0)
+            return;
+    }
+    fs_entry* root = fs_get_root();
+    uint32_t pos = 0;
+    while(pos < root_size){
+        uint8_t len = dir[pos];
+        if(len == 0){
+            pos = (pos + 2048) & ~0x7FF;
+            continue;
+        }
+        uint8_t flags = dir[pos+25];
+        uint8_t name_len = dir[pos+32];
+        const char* name = (char*)&dir[pos+33];
+        if(name_len == 1 && (name[0] == 0 || name[0] == 1)){
+            pos += len;
+            continue;
+        }
+        char fname[32];
+        int j=0;
+        for(int i=0;i<name_len && j<31;i++){
+            char c = name[i];
+            if(c == ';') break;
+            fname[j++] = c;
+        }
+        fname[j] = 0;
+        if(flags & 2){
+            fs_create_dir(root, fname);
+        }else{
+            uint32_t extent = read_le32(dir+pos+2);
+            uint32_t size = read_le32(dir+pos+10);
+            char* data = mem_alloc(size);
+            if(data){
+                for(uint32_t i=0;i<size; i+=2048){
+                    iso_read_sector2048(extent + i/2048, data + i);
+                }
+                fs_entry* f = fs_create_file(root, fname);
+                if(f) fs_write_file(f, data);
+            }
+        }
+        pos += len;
+    }
+}

--- a/OptrixOS-Kernel/src/kernel_main.c
+++ b/OptrixOS-Kernel/src/kernel_main.c
@@ -3,6 +3,7 @@
 #include "driver.h"
 #include "mem.h"
 #include "fs.h"
+#include "iso9660.h"
 
 /* simple heap placed at 0x200000 for illustration */
 #define HEAP_BASE ((unsigned char*)0x200000)
@@ -13,7 +14,7 @@ void kernel_main(void) {
     mem_init(HEAP_BASE, HEAP_SIZE);
     driver_init_all();
 
-    fs_load_sector_file(1, 1, "disksector.bin");
+    iso_populate_fs();
 
     terminal_init();
     terminal_run();


### PR DESCRIPTION
## Summary
- add iso9660.c to read ISO directory entries and populate the memory FS
- include iso9660.h
- integrate ISO parsing in `kernel_main`
- compile new file in Makefile

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs missing)*

------
https://chatgpt.com/codex/tasks/task_e_685358b92994832fb6817e2ae333ab15