### PR TITLE
Embed resources into disk image

### DIFF
--- a/OptrixOS-Kernel/include/resources.h
+++ b/OptrixOS-Kernel/include/resources.h
@@ -1,6 +1,0 @@
-#ifndef RESOURCES_H
-#define RESOURCES_H
-typedef struct { const char* name; const char* data; } resource_file;
-extern const int resource_files_count;
-extern const resource_file resource_files[];
-#endif

--- a/OptrixOS-Kernel/src/resources.c
+++ b/OptrixOS-Kernel/src/resources.c
@@ -1,6 +1,0 @@
-#include "resources.h"
-const resource_file resource_files[] = {
-    {"welcome.txt", "Welcome to OptrixOS!\nEnjoy your stay.\n"},
-    {"logo.txt", "  ____        _   _      ____  _____ \n / __ \\      | | | |    / __ \\|  __ \\\n| |  | |_ __ | |_| |_  | |  | | |__) |\n| |  | | '_ \\| __| __| | |  | |  ___/\n| |__| | | | | |_| |_  | |__| | |    \n \\____/|_| |_|\\__|\\__|  \\____/|_|    \n"},
-};
-const int resource_files_count = 2;

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -95,7 +95,26 @@ static void cmd_banner(void);
 
 static unsigned int uptime = 0;
 static fs_entry* current_dir;
-static char current_path[32] = "/";
+static char current_path[64] = "/";
+
+static void update_path(void){
+    char tmp[64];
+    int idx = sizeof(tmp)-1;
+    tmp[idx] = '\0';
+    fs_entry* p = current_dir;
+    while(p && p != fs_get_root()){
+        const char* n = p->name;
+        int len = t_strlen(n);
+        while(len>0 && idx>0) tmp[--idx] = n[--len];
+        if(idx>0) tmp[--idx] = '/';
+        p = p->parent;
+    }
+    if(idx == sizeof(tmp)-1) tmp[--idx] = '/';
+    int j=0;
+    while(tmp[idx] && j < (int)sizeof(current_path)-1)
+        current_path[j++] = tmp[idx++];
+    current_path[j] = '\0';
+}
 
 static void print_prompt(void){
     print(current_path);
@@ -127,7 +146,27 @@ static void cmd_dir(void){
     }
     put_char('\n');
 }
-static void cmd_cd(const char*args){if(streq(args,"/")||args[0]==0){current_dir=fs_get_root();current_path[0]='/';current_path[1]='\0';return;}if(streq(args,"..")){if(current_dir->parent){current_dir=current_dir->parent;if(current_dir==fs_get_root()){current_path[0]='/';current_path[1]='\0';}else{current_path[0]='/';const char*n=current_dir->name;int i=0;while(n[i]){current_path[i+1]=n[i];i++;}current_path[i+1]='\0';}}return;}fs_entry*d=fs_find_subdir(current_dir,args);if(d){current_dir=d;if(current_dir==fs_get_root()){current_path[0]='/';current_path[1]='\0';}else{current_path[0]='/';int i=0;while(args[i]){current_path[i+1]=args[i];i++;}current_path[i+1]='\0';}}else{print("No such directory\n");}}
+static void cmd_cd(const char*args){
+    if(streq(args,"/")||args[0]==0){
+        current_dir = fs_get_root();
+        update_path();
+        return;
+    }
+    if(streq(args,"..")){
+        if(current_dir->parent){
+            current_dir = current_dir->parent;
+            update_path();
+        }
+        return;
+    }
+    fs_entry* d = fs_find_subdir(current_dir, args);
+    if(d){
+        current_dir = d;
+        update_path();
+    } else {
+        print("No such directory\n");
+    }
+}
 static void cmd_pwd(void){print(current_path);put_char('\n');}
 static void cmd_cat(const char*name){fs_entry*f=fs_find_entry(current_dir,name);if(f&&!f->is_dir){print(fs_read_file(f));put_char('\n');}else print("File not found\n");}
 static void cmd_touch(const char*name){if(fs_find_entry(current_dir,name)){print("Exists\n");return;}if(fs_create_file(current_dir,name))print("Created\n");else print("Fail\n");}
@@ -194,6 +233,7 @@ void terminal_init(void){
     screen_clear();
     fs_init();
     current_dir=fs_get_root();
+    update_path();
     fs_entry* logo = fs_find_entry(current_dir, "logo.txt");
     if(logo) {
         print(fs_read_file(logo));

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -94,24 +94,6 @@ def compile_c(src, out):
 def roundup(x, align):
     return ((x + align - 1) // align) * align
 
-def make_dynamic_img(boot_bin, kernel_bin, img_out):
-    print("Creating dynamically-sized disk image...")
-    boot = open(boot_bin, "rb").read()
-    if len(boot) != 512:
-        print("Error: Bootloader must be exactly 512 bytes!")
-        sys.exit(1)
-    kern = open(kernel_bin, "rb").read()
-    total = 512 + len(kern)
-    min_size = 1474560  # 1.44MB
-    img_size = roundup(total, 512)
-    if img_size < min_size:
-        img_size = min_size
-    with open(img_out, "wb") as img:
-        img.write(boot)
-        img.write(kern)
-        img.write(b'\0' * (img_size - total))
-    print(f"Disk image ({img_size // 1024} KB) created (kernel+boot: {total} bytes).")
-    tmp_files.append(img_out)
 
 def collect_source_files(rootdir):
     asm_files, c_files, h_files = [], [], []
@@ -128,56 +110,55 @@ def collect_source_files(rootdir):
                 h_files.append(path)
     return asm_files, c_files, h_files
 
-# === BINARY RESOURCE EMBEDDING LOGIC ===
-# No binary resources for the text mode build
+
+# === RESOURCE DISK IMAGE CREATION ===
 RESOURCE_DIR = os.path.join(KERNEL_PROJECT_ROOT, "resources")
-GENERATED_C = os.path.join(KERNEL_PROJECT_ROOT, "src", "resources.c")
-GENERATED_H = os.path.join(KERNEL_PROJECT_ROOT, "include", "resources.h")
-resource_bin_files = []
 
-def generate_resource_files():
-    if not os.path.isdir(RESOURCE_DIR):
-        return
+def build_disk_image(boot_bin, kernel_bin, img_out):
+    print("Creating disk image with resources...")
+    boot = open(boot_bin, "rb").read()
+    kern = open(kernel_bin, "rb").read()
+
+    kernel_sectors = roundup(len(kern), 512) // 512
+    kern_padded = kern.ljust(kernel_sectors * 512, b"\0")
+
+    resource_paths = []
+    if os.path.isdir(RESOURCE_DIR):
+        for f in sorted(os.listdir(RESOURCE_DIR)):
+            resource_paths.append(os.path.join(RESOURCE_DIR, f))
+
     entries = []
-    for root, _, files in os.walk(RESOURCE_DIR):
-        for f in files:
-            path = os.path.join(root, f)
-            rel = os.path.relpath(path, RESOURCE_DIR).replace("\\", "/")
-            with open(path, "r", errors="ignore") as fh:
-                data = fh.read().replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
-            entries.append((rel, data))
-    with open(GENERATED_H, "w") as h:
-        h.write("#ifndef RESOURCES_H\n#define RESOURCES_H\n")
-        h.write("typedef struct { const char* name; const char* data; } resource_file;\n")
-        h.write("extern const int resource_files_count;\n")
-        h.write("extern const resource_file resource_files[];\n")
-        h.write("#endif\n")
-    with open(GENERATED_C, "w") as c:
-        c.write('#include "resources.h"\n')
-        c.write("const resource_file resource_files[] = {\n")
-        for name, data in entries:
-            c.write(f'    {{"{name}", "{data}"}},\n')
-        c.write("};\n")
-        c.write(f"const int resource_files_count = {len(entries)};\n")
-    return GENERATED_C
+    data_sectors = []
+    lba_start = 2 + kernel_sectors
+    for i, path in enumerate(resource_paths):
+        with open(path, "rb") as fh:
+            data = fh.read(512)
+        data_sectors.append(data.ljust(512, b"\0"))
+        name = os.path.basename(path)[:15]
+        entries.append((name, lba_start + i, len(data)))
 
-def objcopy_binary(input_path, output_obj):
-    if not os.path.exists(input_path):
-        print(f"ERROR: Resource not found: {input_path}")
-        sys.exit(1)
-    # Only rebuild if changed
-    if not os.path.exists(output_obj) or os.path.getmtime(output_obj) < os.path.getmtime(input_path):
-        print(f"Embedding resource: {input_path} -> {output_obj}")
-        result = subprocess.run([
-            "objcopy", "-I", "binary", "-O", "elf32-i386", "-B", "i386",
-            input_path, output_obj
-        ], capture_output=True, text=True)
-        if result.returncode != 0:
-            print("objcopy failed:", result.stdout, result.stderr)
-            sys.exit(1)
-        tmp_files.append(output_obj)
-    else:
-        print(f"Resource already up to date: {output_obj}")
+    import struct
+    table = struct.pack("<I", len(entries))
+    for name, lba, size in entries:
+        nb = name.encode("ascii", "ignore")
+        nb = nb[:15] + b"\0" * (16 - len(nb))
+        table += nb + struct.pack("<II", lba, size)
+    table = table.ljust(512, b"\0")
+
+    total = 512 + len(table) + len(kern_padded) + len(data_sectors) * 512
+    min_size = 1474560
+    img_size = roundup(total, 512)
+    if img_size < min_size:
+        img_size = min_size
+
+    with open(img_out, "wb") as img:
+        img.write(boot)
+        img.write(table)
+        img.write(kern_padded)
+        for sec in data_sectors:
+            img.write(sec)
+        img.write(b"\0" * (img_size - (512 + len(table) + len(kern_padded) + len(data_sectors) * 512)))
+    print(f"Disk image ({img_size // 1024} KB) created with {len(entries)} resources.")
 
 
 def build_kernel(asm_files, c_files, out_bin):
@@ -302,13 +283,10 @@ def main():
         print('Disk driver source detected')
     else:
         print('Warning: disk.c not found, disk driver missing')
-    res_c = generate_resource_files()
-    if res_c and res_c not in c_files:
-        c_files.append(res_c)
     c_files = list(dict.fromkeys(c_files))
     print(f"Found {len(asm_files)} asm, {len(c_files)} c, {len(h_files)} h files.")
     boot_bin, kernel_bin = build_kernel(asm_files, c_files, out_bin=KERNEL_BIN)
-    make_dynamic_img(boot_bin, kernel_bin, DISK_IMG)
+    build_disk_image(boot_bin, kernel_bin, DISK_IMG)
     copy_tree_to_iso(TMP_ISO_DIR, KERNEL_PROJECT_ROOT)
     make_iso_with_tree(TMP_ISO_DIR, OUTPUT_ISO)
 


### PR DESCRIPTION
## Summary
- remove previously generated resources.c/h
- embed resource files directly into the disk image during build
- update terminal to keep and display full directory path

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853642338b8832fa74a595f72f7d4d6