### PR TITLE
Add data disk and improved path prompt

### DIFF
--- a/OptrixOS-Kernel/include/disk.h
+++ b/OptrixOS-Kernel/include/disk.h
@@ -5,4 +5,5 @@ void ata_init(void);
 int ata_detect(void);
 int ata_read_sector(uint32_t lba, void* buffer);
 int ata_write_sector(uint32_t lba, const void* buffer);
+void ata_set_base(uint16_t base);
 #endif

--- a/OptrixOS-Kernel/include/resources.h
+++ b/OptrixOS-Kernel/include/resources.h
@@ -1,6 +1,0 @@
-#ifndef RESOURCES_H
-#define RESOURCES_H
-typedef struct { const char* name; const char* data; } resource_file;
-extern const int resource_files_count;
-extern const resource_file resource_files[];
-#endif

--- a/OptrixOS-Kernel/src/disk.c
+++ b/OptrixOS-Kernel/src/disk.c
@@ -10,8 +10,14 @@
 #define ATA_COMMAND 7
 #define ATA_DATA 0
 
+#include <stdint.h>
+
 static uint16_t ata_io_base = 0x1F0;
 #define ATA_REG(r) (ata_io_base + (r))
+
+void ata_set_base(uint16_t base){
+    ata_io_base = base;
+}
 #define ATA_STATUS ATA_REG(ATA_STATUS_REG)
 #define ATA_CMD_READ_PIO 0x20
 #define ATA_CMD_WRITE_PIO 0x30

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -118,6 +118,7 @@ const char* fs_read_file(fs_entry* file){
 
 void fs_init(void){
     ata_init();
+    ata_set_base(0x170);
     ata_read_sector(1, &root_table);
     root_dir.name="/";
     root_dir.is_dir=1;

--- a/OptrixOS-Kernel/src/resources.c
+++ b/OptrixOS-Kernel/src/resources.c
@@ -1,6 +1,0 @@
-#include "resources.h"
-const resource_file resource_files[] = {
-    {"welcome.txt", "Welcome to OptrixOS!\nEnjoy your stay.\n"},
-    {"logo.txt", "  ____        _   _      ____  _____ \n / __ \\      | | | |    / __ \\|  __ \\\n| |  | |_ __ | |_| |_  | |  | | |__) |\n| |  | | '_ \\| __| __| | |  | |  ___/\n| |__| | | | | |_| |_  | |__| | |    \n \\____/|_| |_|\\__|\\__|  \\____/|_|    \n"},
-};
-const int resource_files_count = 2;

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -95,7 +95,34 @@ static void cmd_banner(void);
 
 static unsigned int uptime = 0;
 static fs_entry* current_dir;
-static char current_path[32] = "/";
+static char current_path[64] = "/";
+
+static void update_current_path(void){
+    int pos = 0;
+    fs_entry* stack[8];
+    int depth = 0;
+    fs_entry* d = current_dir;
+    while(d && d != fs_get_root() && depth < 8){
+        stack[depth++] = d;
+        d = d->parent;
+    }
+    current_path[pos++] = '/';
+    for(int i=depth-1;i>=0;i--){
+        const char* n = stack[i]->name;
+        for(int j=0;n[j] && pos < (int)sizeof(current_path)-1;j++)
+            current_path[pos++] = n[j];
+        if(i>0 && pos < (int)sizeof(current_path)-1)
+            current_path[pos++] = '/';
+    }
+    current_path[pos]='\0';
+}
+
+static void change_dir(fs_entry* dir){
+    if(dir){
+        current_dir = dir;
+        update_current_path();
+    }
+}
 
 static void print_prompt(void){
     print(current_path);
@@ -127,7 +154,19 @@ static void cmd_dir(void){
     }
     put_char('\n');
 }
-static void cmd_cd(const char*args){if(streq(args,"/")||args[0]==0){current_dir=fs_get_root();current_path[0]='/';current_path[1]='\0';return;}if(streq(args,"..")){if(current_dir->parent){current_dir=current_dir->parent;if(current_dir==fs_get_root()){current_path[0]='/';current_path[1]='\0';}else{current_path[0]='/';const char*n=current_dir->name;int i=0;while(n[i]){current_path[i+1]=n[i];i++;}current_path[i+1]='\0';}}return;}fs_entry*d=fs_find_subdir(current_dir,args);if(d){current_dir=d;if(current_dir==fs_get_root()){current_path[0]='/';current_path[1]='\0';}else{current_path[0]='/';int i=0;while(args[i]){current_path[i+1]=args[i];i++;}current_path[i+1]='\0';}}else{print("No such directory\n");}}
+static void cmd_cd(const char*args){
+    if(streq(args,"/")||args[0]==0){
+        change_dir(fs_get_root());
+        return;
+    }
+    if(streq(args,"..")){
+        if(current_dir->parent)
+            change_dir(current_dir->parent);
+        return;
+    }
+    fs_entry*d=fs_find_subdir(current_dir,args);
+    if(d) change_dir(d); else print("No such directory\n");
+}
 static void cmd_pwd(void){print(current_path);put_char('\n');}
 static void cmd_cat(const char*name){fs_entry*f=fs_find_entry(current_dir,name);if(f&&!f->is_dir){print(fs_read_file(f));put_char('\n');}else print("File not found\n");}
 static void cmd_touch(const char*name){if(fs_find_entry(current_dir,name)){print("Exists\n");return;}if(fs_create_file(current_dir,name))print("Created\n");else print("Fail\n");}
@@ -194,6 +233,7 @@ void terminal_init(void){
     screen_clear();
     fs_init();
     current_dir=fs_get_root();
+    update_current_path();
     fs_entry* logo = fs_find_entry(current_dir, "logo.txt");
     if(logo) {
         print(fs_read_file(logo));

--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ python3 setup_bootloader.py
 ```
 
 If `mkisofs` is available an ISO named `OptrixOS.iso` is created. Otherwise the
-script outputs `disk.img` which can be run with:
+script outputs `boot.img` and `hdd.img` which can be run with:
 
 ```bash
-qemu-system-x86_64 -hda disk.img
+qemu-system-x86_64 -drive format=raw,file=boot.img,if=floppy \
+                   -drive format=raw,file=hdd.img
 ```
 
 ## Built-in terminal


### PR DESCRIPTION
## Summary
- mount filesystem on secondary drive
- remove resources.c build step and create data disk with resources
- show full directory path in shell prompt
- document new boot and data image names

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs.exe not found)*

------
https://chatgpt.com/codex/tasks/task_e_685365b1d278832f8897183a5d6146e9