### PR TITLE
Embed resources on second disk

### DIFF
--- a/OptrixOS-Kernel/include/disk.h
+++ b/OptrixOS-Kernel/include/disk.h
@@ -3,6 +3,9 @@
 #include <stdint.h>
 void ata_init(void);
 int ata_detect(void);
+int ata_read_sector_drive(uint8_t drive, uint32_t lba, void* buffer);
+int ata_write_sector_drive(uint8_t drive, uint32_t lba, const void* buffer);
+/* Convenience wrappers that operate on the first drive */
 int ata_read_sector(uint32_t lba, void* buffer);
 int ata_write_sector(uint32_t lba, const void* buffer);
 #endif

--- a/OptrixOS-Kernel/include/resources.h
+++ b/OptrixOS-Kernel/include/resources.h
@@ -1,6 +1,0 @@
-#ifndef RESOURCES_H
-#define RESOURCES_H
-typedef struct { const char* name; const char* data; } resource_file;
-extern const int resource_files_count;
-extern const resource_file resource_files[];
-#endif

--- a/OptrixOS-Kernel/src/disk.c
+++ b/OptrixOS-Kernel/src/disk.c
@@ -42,14 +42,14 @@ void ata_init(void){
     ata_wait_bsy();
 }
 
-int ata_read_sector(uint32_t lba, void* buffer){
+int ata_read_sector_drive(uint8_t drive, uint32_t lba, void* buffer){
     uint16_t* buf = (uint16_t*)buffer;
     ata_wait_bsy();
     outb(ATA_REG(ATA_SECTOR_COUNT), 1);
     outb(ATA_REG(ATA_LBA_LOW), (uint8_t)lba);
     outb(ATA_REG(ATA_LBA_MID), (uint8_t)(lba >> 8));
     outb(ATA_REG(ATA_LBA_HIGH), (uint8_t)(lba >> 16));
-    outb(ATA_REG(ATA_DRIVE), 0xE0 | ((lba >> 24) & 0x0F));
+    outb(ATA_REG(ATA_DRIVE), 0xE0 | ((drive & 1) << 4) | ((lba >> 24) & 0x0F));
     outb(ATA_REG(ATA_COMMAND), ATA_CMD_READ_PIO);
     ata_wait_bsy();
     ata_wait_drq();
@@ -58,14 +58,14 @@ int ata_read_sector(uint32_t lba, void* buffer){
     return 0;
 }
 
-int ata_write_sector(uint32_t lba, const void* buffer){
+int ata_write_sector_drive(uint8_t drive, uint32_t lba, const void* buffer){
     const uint16_t* buf = (const uint16_t*)buffer;
     ata_wait_bsy();
     outb(ATA_REG(ATA_SECTOR_COUNT), 1);
     outb(ATA_REG(ATA_LBA_LOW), (uint8_t)lba);
     outb(ATA_REG(ATA_LBA_MID), (uint8_t)(lba >> 8));
     outb(ATA_REG(ATA_LBA_HIGH), (uint8_t)(lba >> 16));
-    outb(ATA_REG(ATA_DRIVE), 0xE0 | ((lba >> 24) & 0x0F));
+    outb(ATA_REG(ATA_DRIVE), 0xE0 | ((drive & 1) << 4) | ((lba >> 24) & 0x0F));
     outb(ATA_REG(ATA_COMMAND), ATA_CMD_WRITE_PIO);
     ata_wait_bsy();
     ata_wait_drq();
@@ -73,4 +73,12 @@ int ata_write_sector(uint32_t lba, const void* buffer){
         outw(ATA_REG(ATA_DATA), buf[i]);
     ata_wait_bsy();
     return 0;
+}
+
+int ata_read_sector(uint32_t lba, void* buffer){
+    return ata_read_sector_drive(0, lba, buffer);
+}
+
+int ata_write_sector(uint32_t lba, const void* buffer){
+    return ata_write_sector_drive(0, lba, buffer);
 }

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -18,6 +18,7 @@ typedef struct {
 } disk_root;
 
 static disk_root root_table;
+#define FS_DRIVE 1
 static fs_entry root_dir;
 
 static size_t fs_strlen(const char* s){ size_t l=0; while(s[l]) l++; return l; }
@@ -111,14 +112,14 @@ const char* fs_read_file(fs_entry* file){
     if(!file||file->is_dir) return "";
     uint32_t lba = (uint32_t)(uintptr_t)file->content;
     char* buf = mem_alloc(512+1);
-    ata_read_sector(lba, buf);
+    ata_read_sector_drive(FS_DRIVE, lba, buf);
     buf[512]=0;
     return buf;
 }
 
 void fs_init(void){
     ata_init();
-    ata_read_sector(1, &root_table);
+    ata_read_sector_drive(FS_DRIVE, 1, &root_table);
     root_dir.name="/";
     root_dir.is_dir=1;
     root_dir.parent=NULL;

--- a/OptrixOS-Kernel/src/resources.c
+++ b/OptrixOS-Kernel/src/resources.c
@@ -1,6 +1,0 @@
-#include "resources.h"
-const resource_file resource_files[] = {
-    {"welcome.txt", "Welcome to OptrixOS!\nEnjoy your stay.\n"},
-    {"logo.txt", "  ____        _   _      ____  _____ \n / __ \\      | | | |    / __ \\|  __ \\\n| |  | |_ __ | |_| |_  | |  | | |__) |\n| |  | | '_ \\| __| __| | |  | |  ___/\n| |__| | | | | |_| |_  | |__| | |    \n \\____/|_| |_|\\__|\\__|  \\____/|_|    \n"},
-};
-const int resource_files_count = 2;

--- a/README.md
+++ b/README.md
@@ -36,10 +36,13 @@ python3 setup_bootloader.py
 ```
 
 If `mkisofs` is available an ISO named `OptrixOS.iso` is created. Otherwise the
-script outputs `disk.img` which can be run with:
+script outputs `disk.img` and `resources.img`. The latter contains all files
+from the `resources` folder. Attach both images as separate drives when running
+with QEMU. For example:
 
 ```bash
-qemu-system-x86_64 -hda disk.img
+qemu-system-x86_64 -drive format=raw,file=disk.img \
+                   -drive format=raw,file=resources.img
 ```
 
 ## Built-in terminal

--- a/Run_OptrixOS.bat
+++ b/Run_OptrixOS.bat
@@ -1,3 +1,3 @@
 @echo off
 
-qemu-system-x86_64 -cdrom OptrixOS.iso
+qemu-system-x86_64 -drive format=raw,file=disk.img -drive format=raw,file=resources.img

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -128,38 +128,47 @@ def collect_source_files(rootdir):
                 h_files.append(path)
     return asm_files, c_files, h_files
 
-# === BINARY RESOURCE EMBEDDING LOGIC ===
-# No binary resources for the text mode build
+# === RESOURCE DISK IMAGE CREATION ===
 RESOURCE_DIR = os.path.join(KERNEL_PROJECT_ROOT, "resources")
-GENERATED_C = os.path.join(KERNEL_PROJECT_ROOT, "src", "resources.c")
-GENERATED_H = os.path.join(KERNEL_PROJECT_ROOT, "include", "resources.h")
-resource_bin_files = []
+RESOURCE_IMG = "resources.img"
 
-def generate_resource_files():
-    if not os.path.isdir(RESOURCE_DIR):
+def build_resource_disk(resource_dir, out_img):
+    if not os.path.isdir(resource_dir):
         return
+    import struct
+    print("Building resource disk image...")
+    files = []
+    for f in sorted(os.listdir(resource_dir)):
+        path = os.path.join(resource_dir, f)
+        if os.path.isfile(path):
+            with open(path, "rb") as fh:
+                data = fh.read()
+            files.append((f, data))
+
     entries = []
-    for root, _, files in os.walk(RESOURCE_DIR):
-        for f in files:
-            path = os.path.join(root, f)
-            rel = os.path.relpath(path, RESOURCE_DIR).replace("\\", "/")
-            with open(path, "r", errors="ignore") as fh:
-                data = fh.read().replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")
-            entries.append((rel, data))
-    with open(GENERATED_H, "w") as h:
-        h.write("#ifndef RESOURCES_H\n#define RESOURCES_H\n")
-        h.write("typedef struct { const char* name; const char* data; } resource_file;\n")
-        h.write("extern const int resource_files_count;\n")
-        h.write("extern const resource_file resource_files[];\n")
-        h.write("#endif\n")
-    with open(GENERATED_C, "w") as c:
-        c.write('#include "resources.h"\n')
-        c.write("const resource_file resource_files[] = {\n")
-        for name, data in entries:
-            c.write(f'    {{"{name}", "{data}"}},\n')
-        c.write("};\n")
-        c.write(f"const int resource_files_count = {len(entries)};\n")
-    return GENERATED_C
+    lba = 2
+    data_blocks = []
+    for name, data in files:
+        sectors = roundup(len(data), 512) // 512
+        entries.append((name[:15], lba, len(data)))
+        padded = data + b"\0" * (sectors*512 - len(data))
+        data_blocks.append(padded)
+        lba += sectors
+
+    root = struct.pack('<I', len(entries))
+    for name, lba_val, size in entries:
+        nb = name.encode('ascii')[:15]
+        nb += b'\0' * (16 - len(nb))
+        root += struct.pack('<16sII', nb, lba_val, size)
+    root = root.ljust(512, b'\0')
+
+    with open(out_img, 'wb') as img:
+        img.write(b'\0' * 512)
+        img.write(root)
+        for block in data_blocks:
+            img.write(block)
+    tmp_files.append(out_img)
+    print(f"Resource disk image created: {out_img}")
 
 def objcopy_binary(input_path, output_obj):
     if not os.path.exists(input_path):
@@ -248,9 +257,11 @@ def copy_tree_to_iso(tmp_iso_dir, proj_root):
     kernel_dest = os.path.join(tmp_iso_dir, os.path.basename(proj_root))
     shutil.copytree(proj_root, kernel_dest, ignore=ignore_git, dirs_exist_ok=True)
 
-    # Place disk image at ISO root
+    # Place disk images at ISO root
     if os.path.exists(DISK_IMG):
         shutil.copy(DISK_IMG, os.path.join(tmp_iso_dir, "disk.img"))
+    if os.path.exists(RESOURCE_IMG):
+        shutil.copy(RESOURCE_IMG, os.path.join(tmp_iso_dir, "resources.img"))
 
 
 def make_iso_with_tree(tmp_iso_dir, iso_out):
@@ -302,13 +313,11 @@ def main():
         print('Disk driver source detected')
     else:
         print('Warning: disk.c not found, disk driver missing')
-    res_c = generate_resource_files()
-    if res_c and res_c not in c_files:
-        c_files.append(res_c)
     c_files = list(dict.fromkeys(c_files))
     print(f"Found {len(asm_files)} asm, {len(c_files)} c, {len(h_files)} h files.")
     boot_bin, kernel_bin = build_kernel(asm_files, c_files, out_bin=KERNEL_BIN)
     make_dynamic_img(boot_bin, kernel_bin, DISK_IMG)
+    build_resource_disk(RESOURCE_DIR, RESOURCE_IMG)
     copy_tree_to_iso(TMP_ISO_DIR, KERNEL_PROJECT_ROOT)
     make_iso_with_tree(TMP_ISO_DIR, OUTPUT_ISO)
 


### PR DESCRIPTION
## Summary
- embed files from `resources` directory into a dedicated `resources.img`
- remove generated `resources.c`/`resources.h`
- add drive parameter to disk driver and update filesystem to load from second disk
- update build script to create `resources.img`
- revise run instructions and README

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68536a1ed2f4832f8b4c8879f3bf7334