### PR TITLE
Embed resources in disk image

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -30,13 +30,13 @@ start:
     jmp .printloop
 .doneprint:
 
-    ; load kernel (assumes kernel starts at second sector)
+    ; load kernel (assumes kernel starts at third sector)
     mov bx, 0x1000    ; ES:BX points to load address
     mov dl, [BOOT_DRIVE]
     mov dh, 0         ; head
     mov ah, 0x02      ; BIOS read disk
     mov al, KERNEL_SECTORS
-    mov cx, 0x0002    ; CH=0, CL=2 (sector 2)
+    mov cx, 0x0003    ; CH=0, CL=3 (sector 3)
     int 0x13
 
     ; setup basic GDT for protected mode


### PR DESCRIPTION
## Summary
- load kernel from sector 3 so sector 2 can store a root table
- write a `make_disk_with_resources` helper in the build script
- skip generating `resources.c` and place resource files on disk instead

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68536f21b9b8832f97dbdf558757b899