### PR TITLE
Add disk file handler for large resources

### DIFF
--- a/OptrixOS-Kernel/include/fs.h
+++ b/OptrixOS-Kernel/include/fs.h
@@ -7,7 +7,9 @@ typedef struct fs_entry {
     struct fs_entry* parent;
     struct fs_entry* child;
     struct fs_entry* sibling;
-    char* content;
+    char* content; /* for in-memory files */
+    unsigned int lba;  /* starting sector on disk */
+    unsigned int size; /* file size in bytes */
 } fs_entry;
 
 fs_entry* fs_find_entry(fs_entry* dir, const char* name);


### PR DESCRIPTION
## Summary
- enhance file system to store file location and size on disk
- load an extended resource table from multiple sectors
- update build script to embed resources without 512 byte limit

## Testing
- `python3 setup_bootloader.py` *(fails: `mkisofs.exe not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685370bcd824832fa7321d42ebfbcf17