### PR TITLE
Fix resource embedding layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Build the bootable image with:
 python3 setup_bootloader.py
 ```
 
+The script embeds all files from `OptrixOS-Kernel/resources` into the
+disk image so they appear in the root directory when the OS boots.
+
 If `mkisofs` is available an ISO named `OptrixOS.iso` is created. Otherwise the
 script outputs `disk.img` which can be run with:
 

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -123,8 +123,11 @@ def make_disk_with_resources(boot_bin, kernel_bin, img_out):
     entry_size = struct.calcsize(ENTRY_STRUCT)
 
     root_entries = []
+    # The bootloader always loads the kernel starting from sector 3, so the
+    # resource table must occupy two full sectors even when the actual data is
+    # smaller.  This keeps the kernel aligned to sector 3.
     root_bytes = 4 + entry_size * len(resources)
-    root_sectors = roundup(root_bytes, 512) // 512
+    root_sectors = max(2, roundup(root_bytes, 512) // 512)
 
     kernel_start = 1 + root_sectors
     resource_start = kernel_start + kernel_sectors


### PR DESCRIPTION
## Summary
- keep resource table at two sectors so bootloader loads kernel correctly
- mention resource embedding in the README

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68537375de1c832fa4f17cd8779c4394