### PR TITLE
Add directory support and embed resources folder

### DIFF
--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -116,7 +116,8 @@ def make_disk_with_resources(boot_bin, kernel_bin, img_out):
             size = len(data)
             pad = roundup(size, 512)
             data += b"\0" * (pad - size)
-            resources.append({"name": name, "data": data, "size": size})
+            disk_name = f"resources/{name}"
+            resources.append({"name": disk_name, "data": data, "size": size})
 
     import struct
     ENTRY_STRUCT = "<32sII"


### PR DESCRIPTION
## Summary
- support nested paths when initializing files from disk
- embed resources in a subfolder (`resources/`) in disk image

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68537712c348832f99e3ccdeed4be798