### PR TITLE
Fix resources path in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.bin
 *.img
 *.o
+*.elf

--- a/README.md
+++ b/README.md
@@ -73,3 +73,7 @@ The following commands are implemented:
 
 ### Resources
 Files inside `OptrixOS-Kernel/resources` are packed onto the disk image under `/resources`. On boot the kernel prints `hello.txt` from this directory to demonstrate reading files from the ISO.
+
+`setup_bootloader.py` now resolves the resources directory using its own
+location so it can be invoked from any path and still include the files
+correctly.

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -31,8 +31,8 @@ if not os.path.isfile(MKISOFS_EXE):
     MKISOFS_EXE = shutil.which("mkisofs") or "mkisofs"
 
 # Only build sources inside the kernel directory
-KERNEL_PROJECT_ROOT = "OptrixOS-Kernel"
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+KERNEL_PROJECT_ROOT = os.path.join(SCRIPT_DIR, "OptrixOS-Kernel")
 OUTPUT_ISO = os.path.join(SCRIPT_DIR, "OptrixOS.iso")
 KERNEL_BIN = "OptrixOS-kernel.bin"
 DISK_IMG = "disk.img"


### PR DESCRIPTION
## Summary
- fix path resolution in `setup_bootloader.py`
- note that `setup_bootloader.py` now finds its resources regardless of cwd
- ignore `.elf` files

## Testing
- `python3 setup_bootloader.py` *(fails: `mkisofs.exe not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68537ca0b14c832fb7e3f1b3bb42b1f7