### PR TITLE
Fix resources folder handling

### DIFF
--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -202,4 +202,10 @@ void fs_init(void){
             }
         }
     }
+
+    /* Ensure the resources directory exists even if no files were
+       embedded. This prevents the shell from reporting it missing
+       and allows users to add files later. */
+    if(!fs_find_subdir(&root_dir, "resources"))
+        fs_create_dir(&root_dir, "resources");
 }

--- a/README.md
+++ b/README.md
@@ -72,8 +72,11 @@ The following commands are implemented:
 
 
 ### Resources
-Files inside `OptrixOS-Kernel/resources` are packed onto the disk image under `/resources`. On boot the kernel prints `hello.txt` from this directory to demonstrate reading files from the ISO.
+Files inside `OptrixOS-Kernel/resources` are packed onto the disk image
+under `/resources`. Subdirectories are included as well. Even if no
+resource files are present the `/resources` directory will still be
+created so it is always available from within the OS.
 
-`setup_bootloader.py` now resolves the resources directory using its own
+`setup_bootloader.py` resolves the resources directory using its own
 location so it can be invoked from any path and still include the files
 correctly.

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -107,17 +107,17 @@ def make_disk_with_resources(boot_bin, kernel_bin, img_out):
 
     resources = []
     if os.path.isdir(RESOURCE_DIR):
-        for name in sorted(os.listdir(RESOURCE_DIR)):
-            path = os.path.join(RESOURCE_DIR, name)
-            if not os.path.isfile(path):
-                continue
-            with open(path, "rb") as fh:
-                data = fh.read()
-            size = len(data)
-            pad = roundup(size, 512)
-            data += b"\0" * (pad - size)
-            disk_name = f"resources/{name}"
-            resources.append({"name": disk_name, "data": data, "size": size})
+        for root, _, files in os.walk(RESOURCE_DIR):
+            for name in sorted(files):
+                path = os.path.join(root, name)
+                with open(path, "rb") as fh:
+                    data = fh.read()
+                size = len(data)
+                pad = roundup(size, 512)
+                data += b"\0" * (pad - size)
+                rel = os.path.relpath(path, RESOURCE_DIR).replace("\\", "/")
+                disk_name = f"resources/{rel}"
+                resources.append({"name": disk_name, "data": data, "size": size})
 
     import struct
     ENTRY_STRUCT = "<32sII"


### PR DESCRIPTION
## Summary
- ensure resources directory always exists at boot even if empty
- include nested resource files on disk image
- document updated resource handling

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68537e4ba530832fba510d80712bd307