### PR TITLE
Embed resources into kernel

### DIFF
--- a/OptrixOS-Kernel/include/fs.h
+++ b/OptrixOS-Kernel/include/fs.h
@@ -10,6 +10,7 @@ typedef struct fs_entry {
     char* content; /* for in-memory files */
     unsigned int lba;  /* starting sector on disk */
     unsigned int size; /* file size in bytes */
+    int embedded; /* 1 if the file was embedded in the kernel */
 } fs_entry;
 
 fs_entry* fs_find_entry(fs_entry* dir, const char* name);

--- a/OptrixOS-Kernel/include/resources.h
+++ b/OptrixOS-Kernel/include/resources.h
@@ -3,4 +3,5 @@
 typedef struct { const char* name; const char* data; } resource_file;
 extern const int resource_files_count;
 extern const resource_file resource_files[];
+void resources_embed(void);
 #endif

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -1,6 +1,7 @@
 #include "fs.h"
 #include "mem.h"
 #include "disk.h"
+#include "resources.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -30,6 +31,7 @@ static fs_entry* alloc_entry(const char*name,int is_dir){
     e->content=NULL;
     e->lba=0;
     e->size=0;
+    e->embedded=0;
     return e;
 }
 
@@ -173,6 +175,7 @@ void fs_init(void){
     root_dir.content=NULL;
     root_dir.lba=0;
     root_dir.size=0;
+    root_dir.embedded=0;
 
     for(uint32_t i=0;i<disk_file_count;i++){
         const char* name = disk_files[i].name;
@@ -208,4 +211,6 @@ void fs_init(void){
        and allows users to add files later. */
     if(!fs_find_subdir(&root_dir, "resources"))
         fs_create_dir(&root_dir, "resources");
+
+    resources_embed();
 }

--- a/OptrixOS-Kernel/src/resources.c
+++ b/OptrixOS-Kernel/src/resources.c
@@ -1,6 +1,28 @@
 #include "resources.h"
+#include "fs.h"
+
 const resource_file resource_files[] = {
     {"welcome.txt", "Welcome to OptrixOS!\nEnjoy your stay.\n"},
-    {"logo.txt", "  ____        _   _      ____  _____ \n / __ \\      | | | |    / __ \\|  __ \\\n| |  | |_ __ | |_| |_  | |  | | |__) |\n| |  | | '_ \\| __| __| | |  | |  ___/\n| |__| | | | | |_| |_  | |__| | |    \n \\____/|_| |_|\\__|\\__|  \\____/|_|    \n"},
+    {"logo.txt", "  ____        _   _      ____  _____ \n / __ \\      | | | |    / __ \\|  __ \\
+| |  | |_ __ | |_| |_  | |  | | |__) |\n| |  | | '_ \\| __| __| | |  | |  ___/\n| |__| | | | | |_| |_  | |__| | |    \n \\____/|_| |_|\\__|\\__|  \\____/|_|    \n"},
+    {"hello.txt", "Hello World\n"}
 };
-const int resource_files_count = 2;
+const int resource_files_count = 3;
+
+void resources_embed(void){
+    fs_entry* root = fs_get_root();
+    fs_entry* res_dir = fs_find_subdir(root, "resources");
+    if(!res_dir)
+        res_dir = fs_create_dir(root, "resources");
+
+    for(int i=0;i<resource_files_count;i++){
+        const char* name = resource_files[i].name;
+        fs_entry* f = fs_find_entry(res_dir, name);
+        if(!f)
+            f = fs_create_file(res_dir, name);
+        if(f){
+            fs_write_file(f, resource_files[i].data);
+            f->embedded = 1;
+        }
+    }
+}

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -205,14 +205,21 @@ void terminal_init(void){
     fs_init();
 
     fs_entry* res = fs_find_path("resources");
-    if(res && res->is_dir)
+    if(res && res->is_dir){
         print("resources directory ready\n");
-    else
+        for(fs_entry*f=res->child;f;f=f->sibling){
+            print("  ");
+            print(f->name);
+            print(f->embedded?" [embedded]\n":" [disk]\n");
+        }
+    }else{
         print("resources directory missing\n");
+    }
 
     current_dir=fs_get_root();
     fs_entry* hello = fs_find_path("resources/hello.txt");
     if(hello){
+        print("Contents of hello.txt:\n");
         print(fs_read_file(hello));
         put_char('\n');
     }

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -345,7 +345,7 @@ def main():
     print("Collecting all project source files...")
     asm_files, c_files, h_files = collect_source_files(KERNEL_PROJECT_ROOT)
     # Exclude files that should not be compiled directly
-    c_files = [f for f in c_files if not f.endswith('scheduler.c') and not f.endswith('resources.c')]
+    c_files = [f for f in c_files if not f.endswith('scheduler.c')]
     # Ensure disk driver source is present
     if any(f.endswith('disk.c') for f in c_files):
         print('Disk driver source detected')


### PR DESCRIPTION
## Summary
- add kernel-embedded resources so `/resources` is always available
- show embedded status for files at boot
- list resources and display `hello.txt` in terminal
- build system now compiles `resources.c`

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_685382151ff0832f90291401d8def99d