### PR TITLE
Add resources test demo

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -5,7 +5,7 @@ all: disk.img
 bootloader.bin: asm/bootloader.asm
 	@nasm -f bin $< -o $@
 	
-kernel.bin: asm/kernel.asm asm/ports.asm src/screen.o src/keyboard.o src/terminal.o src/fs.o src/driver.o src/mem.o src/kernel_main.o
+kernel.bin: asm/kernel.asm asm/ports.asm src/screen.o src/keyboard.o src/terminal.o src/fs.o src/driver.o src/mem.o src/kernel_main.o src/disk.o src/resources_test.o
 	@nasm -f elf32 asm/kernel.asm -o kernel_asm.o
 	@nasm -f elf32 asm/ports.asm -o ports.o
 	@gcc $(CFLAGS) -c src/screen.c -o src/screen.o
@@ -15,9 +15,11 @@ kernel.bin: asm/kernel.asm asm/ports.asm src/screen.o src/keyboard.o src/termina
 	@gcc $(CFLAGS) -c src/driver.c -o src/driver.o
 	@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
 	@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
+	@gcc $(CFLAGS) -c src/disk.c -o src/disk.o
+	@gcc $(CFLAGS) -c src/resources_test.c -o src/resources_test.o
 	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
-	src/screen.o src/keyboard.o src/terminal.o src/fs.o \
-	src/driver.o src/mem.o src/kernel_main.o --oformat binary -o $@
+src/screen.o src/keyboard.o src/terminal.o src/fs.o \
+src/driver.o src/mem.o src/kernel_main.o src/disk.o src/resources_test.o --oformat binary -o $@
 	
 disk.img: bootloader.bin kernel.bin
 	@cat bootloader.bin kernel.bin > $@

--- a/OptrixOS-Kernel/include/resources_test.h
+++ b/OptrixOS-Kernel/include/resources_test.h
@@ -1,0 +1,4 @@
+#ifndef RESOURCES_TEST_H
+#define RESOURCES_TEST_H
+void resources_test(void);
+#endif

--- a/OptrixOS-Kernel/src/resources_test.c
+++ b/OptrixOS-Kernel/src/resources_test.c
@@ -1,0 +1,37 @@
+#include "resources_test.h"
+#include "fs.h"
+#include "screen.h"
+#include <stdint.h>
+
+static int r_col = 0;
+static int r_row = 0;
+
+static void r_put(char c){
+    if(c=='\n'){
+        r_row++; r_col=0;
+    } else {
+        screen_put_char(r_col,r_row,c,0x1E);
+        r_col++;
+        if(r_col>=SCREEN_COLS){ r_col=0; r_row++; }
+    }
+}
+
+static void r_print(const char*s){ while(*s) r_put(*s++); }
+
+void resources_test(void){
+    fs_entry* dir = fs_find_path("resources");
+    if(!dir || !dir->is_dir){
+        r_print("resources dir not found\n");
+        return;
+    }
+    r_print("resource files:\n");
+    for(fs_entry* f=dir->child; f; f=f->sibling){
+        r_print(" - ");
+        r_print(f->name);
+        if(f->embedded)
+            r_print(" [embedded]\n");
+        else
+            r_print(" [disk]\n");
+    }
+    r_print("\n");
+}

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -4,6 +4,7 @@
 #include "fs.h"
 #include "disk.h"
 #include "mem.h"
+#include "resources_test.h"
 #include <stdint.h>
 #include <stddef.h>
 
@@ -203,6 +204,9 @@ void terminal_init(void){
         print("No ATA drive found\n");
 
     fs_init();
+
+    /* Debug: list all files embedded from the resources directory */
+    resources_test();
 
     fs_entry* res = fs_find_path("resources");
     if(res && res->is_dir){


### PR DESCRIPTION
## Summary
- add `resources_test` module to list embedded files
- invoke the listing during terminal init
- compile new module and disk driver in the kernel Makefile

## Testing
- `make -C OptrixOS-Kernel clean`
- `make -C OptrixOS-Kernel all`

------
https://chatgpt.com/codex/tasks/task_e_685386e37270832f878850d05135886a