### PR TITLE
Fix embedded resource sector offsets

### DIFF
--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -155,22 +155,27 @@ void fs_init(void){
     root_dir.size=0;
     root_dir.embedded=0;
 
-    uint32_t kernel_bytes = (uint32_t)&end - 0x1000;
-    uint32_t kernel_sectors = (kernel_bytes + 511) / 512;
-
     /*
-       The build script writes a small filesystem table directly after the
-       boot sector. Each entry in that table consists of a 32 byte name
-       followed by the file's starting LBA and size (4 bytes each).  The
-       original implementation mistakenly used sizeof(embedded_resource)
-       (8 bytes) when computing the table size which caused the calculated
-       LBAs to be too small.  As a result files were read from incorrect
-       locations and appeared empty.  Use the on-disk entry size (40 bytes)
-       to mirror the layout used when creating the disk image.
+       Read the filesystem header from disk to obtain the root table and
+       kernel sizes.  This keeps the in-memory filesystem layout consistent
+       with the values used by the bootloader and build script.
     */
-    uint32_t entry_bytes = EMBEDDED_RESOURCE_COUNT * (32 + 4 + 4);
-    uint32_t table_bytes = 12 + entry_bytes;
-    uint32_t root_sectors = (table_bytes + 511) / 512;
+    uint32_t root_sectors = 0;
+    uint32_t kernel_sectors = 0;
+    {
+        unsigned char buf[512];
+        ata_read_sector(1, buf);
+        root_sectors   = ((uint32_t*)buf)[1];
+        kernel_sectors = ((uint32_t*)buf)[2];
+    }
+    /* Fallback to calculated values if the header looked empty */
+    if(root_sectors == 0 || kernel_sectors == 0){
+        uint32_t kernel_bytes = (uint32_t)&end - 0x1000;
+        kernel_sectors = (kernel_bytes + 511) / 512;
+        uint32_t entry_bytes = EMBEDDED_RESOURCE_COUNT * (32 + 4 + 4);
+        uint32_t table_bytes = 12 + entry_bytes;
+        root_sectors = (table_bytes + 511) / 512;
+    }
 
     uint32_t cur_lba = 1 + root_sectors + kernel_sectors;
 


### PR DESCRIPTION
## Summary
- retrieve kernel & root sector counts from the disk header
- fall back to computed values when running without an image

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_685451fd5920832fbebb42b022e61573