### PR TITLE
Embed resource data

### DIFF
--- a/OptrixOS-Kernel/include/embedded_resources.h
+++ b/OptrixOS-Kernel/include/embedded_resources.h
@@ -4,6 +4,7 @@
 
 typedef struct {
     const char* name;
+    const unsigned char* data;
     uint32_t size;
 } embedded_resource;
 

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -193,6 +193,7 @@ void fs_init(void){
                     if(f){
                         f->lba = cur_lba;
                         f->size = embedded_resources[i].size;
+                        f->content = (char*)embedded_resources[i].data;
                         f->embedded = 1;
                     }
                     cur_lba += (embedded_resources[i].size + 511)/512;

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -111,15 +111,21 @@ def generate_embedded_sources(resources):
     with open(EMBED_HEADER, "w") as fh:
         fh.write("#ifndef EMBEDDED_RESOURCES_H\n#define EMBEDDED_RESOURCES_H\n")
         fh.write("#include <stdint.h>\n\n")
-        fh.write("typedef struct { const char* name; uint32_t size; } embedded_resource;\n")
+        fh.write("typedef struct { const char* name; const unsigned char* data; uint32_t size; } embedded_resource;\n")
         fh.write(f"#define EMBEDDED_RESOURCE_COUNT {len(resources)}\n")
         fh.write("extern const embedded_resource embedded_resources[EMBEDDED_RESOURCE_COUNT];\n")
         fh.write("#endif\n")
+
     with open(EMBED_SOURCE, "w") as fc:
         fc.write('#include "embedded_resources.h"\n')
+        for idx, r in enumerate(resources):
+            array_name = f'resource_data_{idx}'
+            bytes_formatted = ','.join(f'0x{b:02x}' for b in r["data"])
+            fc.write(f'static const unsigned char {array_name}[] = {{{bytes_formatted}}};\n')
+            r['array'] = array_name
         fc.write("const embedded_resource embedded_resources[EMBEDDED_RESOURCE_COUNT] = {\n")
         for r in resources:
-            fc.write(f'    {{"{r["name"]}", {r["size"]}}},\n')
+            fc.write(f'    {{"{r["name"]}", {r["array"]}, {r["size"]}}},\n')
         fc.write("};\n")
     tmp_files.extend([EMBED_HEADER, EMBED_SOURCE])
 


### PR DESCRIPTION
## Summary
- embed file contents into `embedded_resources` arrays
- expose resource data pointer in header and FS

## Testing
- `python3 -m py_compile setup_bootloader.py`
- `gcc -m32 -ffreestanding -fno-pie -fno-pic -Iinclude -IOptrixOS-Kernel/include -c OptrixOS-Kernel/src/fs.c -o /tmp/fs.o`
- `gcc -m32 -ffreestanding -fno-pie -fno-pic -Iinclude -IOptrixOS-Kernel/include -c OptrixOS-Kernel/src/embedded_resources.c -o /tmp/embedded_resources.o`


------
https://chatgpt.com/codex/tasks/task_e_685453696560832fb775e908854dc949