### PR TITLE
Handle large disk images in ISO builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ script outputs `disk.img` which can be run with:
 qemu-system-x86_64 -hda disk.img
 ```
 
+When the embedded resources cause `disk.img` to grow beyond standard floppy
+sizes, the build script automatically switches the ISO to *no-emulation* mode so
+larger images continue to boot correctly.
+
 ## Built-in terminal
 
 After boot the machine displays a plain text console. No graphics or windowing

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -316,14 +316,22 @@ def make_iso_with_tree(tmp_iso_dir, iso_out):
         sys.exit(1)
     if os.path.exists(iso_out):
         os.remove(iso_out)
-    cmd = [
-        MKISOFS_EXE,
-        "-quiet",
-        "-o", iso_out,
-        "-b", "disk.img",
-        "-R", "-J", "-l",
-        tmp_iso_dir
-    ]
+    disk_path = os.path.join(tmp_iso_dir, "disk.img")
+    disk_size = os.path.getsize(disk_path) if os.path.exists(disk_path) else 0
+    floppy_sizes = {
+        1200 * 1024,  # 1.2MB
+        1440 * 1024,  # 1.44MB
+        2880 * 1024   # 2.88MB
+    }
+
+    cmd = [MKISOFS_EXE, "-quiet", "-o", iso_out]
+    if disk_size in floppy_sizes:
+        cmd += ["-b", "disk.img"]
+    else:
+        # Larger images cannot be used with floppy emulation. Fall back to
+        # no emulation mode which allows arbitrary sizes.
+        cmd += ["-b", "disk.img", "-no-emul-boot", "-boot-load-size", "4"]
+    cmd += ["-R", "-J", "-l", tmp_iso_dir]
     run(cmd)
     # Forcibly copy ISO to script's dir if not already there
     script_dir = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Summary
- update ISO creation in `setup_bootloader.py` to switch to `-no-emul-boot` when disk.img is not a standard floppy size
- document the new behaviour in README

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs missing)*

------
https://chatgpt.com/codex/tasks/task_e_685454e2be58832faf4b92440ab36954