### PR TITLE
Update mkisofs options

### DIFF
--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -321,6 +321,8 @@ def make_iso_with_tree(tmp_iso_dir, iso_out):
         "-quiet",
         "-o", iso_out,
         "-b", "disk.img",
+        "-no-emul-boot",
+        "-boot-load-size", "4",
         "-R", "-J", "-l",
         tmp_iso_dir
     ]


### PR DESCRIPTION
## Summary
- support using boot images larger than standard floppy sizes

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs.exe not found)*

------
https://chatgpt.com/codex/tasks/task_e_685456ea98f0832fbd4faf72e2cf4eb7