### PR TITLE
Implement external resource disk

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -1,6 +1,6 @@
 CFLAGS=-ffreestanding -fno-pie -fno-pic -m32 -Iinclude
 	
-all: disk.img
+all: boot.img resources.img
 	
 bootloader.bin: asm/bootloader.asm
 	@nasm -f bin $< -o $@
@@ -22,11 +22,14 @@ kernel.bin: asm/kernel.asm asm/ports.asm src/screen.o src/keyboard.o src/termina
 src/screen.o src/keyboard.o src/terminal.o src/fs.o \
 src/driver.o src/mem.o src/kernel_main.o src/disk.o src/resources_test.o src/embedded_resources.o --oformat binary -o $@
 	
-disk.img: bootloader.bin kernel.bin
-	@cat bootloader.bin kernel.bin > $@
+boot.img: bootloader.bin kernel.bin
+        @cat bootloader.bin kernel.bin > $@
+
+resources.img:
+        @echo "Use setup_bootloader.py to create resources.img"
 	
-run: disk.img
-	@qemu-system-i386 -drive format=raw,file=disk.img
+run: boot.img resources.img
+        @qemu-system-i386 -drive format=raw,file=boot.img -drive format=raw,file=resources.img,media=disk,if=ide,index=1
 	
 clean:
-	@rm -f *.bin *.o disk.img src/*.o kernel_asm.o
+        @rm -f *.bin *.o boot.img resources.img src/*.o kernel_asm.o

--- a/OptrixOS-Kernel/include/disk.h
+++ b/OptrixOS-Kernel/include/disk.h
@@ -3,6 +3,8 @@
 #include <stdint.h>
 void ata_init(void);
 int ata_detect(void);
+/* Select ATA drive 0=master, 1=slave */
+void ata_select_drive(int drive);
 int ata_read_sector(uint32_t lba, void* buffer);
 int ata_write_sector(uint32_t lba, const void* buffer);
 #endif

--- a/OptrixOS-Kernel/src/disk.c
+++ b/OptrixOS-Kernel/src/disk.c
@@ -11,6 +11,7 @@
 #define ATA_DATA 0
 
 static uint16_t ata_io_base = 0x1F0;
+static uint8_t ata_drive = 0;
 #define ATA_REG(r) (ata_io_base + (r))
 #define ATA_STATUS ATA_REG(ATA_STATUS_REG)
 #define ATA_CMD_READ_PIO 0x20
@@ -42,6 +43,10 @@ void ata_init(void){
     ata_wait_bsy();
 }
 
+void ata_select_drive(int drive){
+    ata_drive = (drive ? 1 : 0);
+}
+
 int ata_read_sector(uint32_t lba, void* buffer){
     uint16_t* buf = (uint16_t*)buffer;
     ata_wait_bsy();
@@ -49,7 +54,7 @@ int ata_read_sector(uint32_t lba, void* buffer){
     outb(ATA_REG(ATA_LBA_LOW), (uint8_t)lba);
     outb(ATA_REG(ATA_LBA_MID), (uint8_t)(lba >> 8));
     outb(ATA_REG(ATA_LBA_HIGH), (uint8_t)(lba >> 16));
-    outb(ATA_REG(ATA_DRIVE), 0xE0 | ((lba >> 24) & 0x0F));
+    outb(ATA_REG(ATA_DRIVE), 0xE0 | (ata_drive << 4) | ((lba >> 24) & 0x0F));
     outb(ATA_REG(ATA_COMMAND), ATA_CMD_READ_PIO);
     ata_wait_bsy();
     ata_wait_drq();
@@ -65,7 +70,7 @@ int ata_write_sector(uint32_t lba, const void* buffer){
     outb(ATA_REG(ATA_LBA_LOW), (uint8_t)lba);
     outb(ATA_REG(ATA_LBA_MID), (uint8_t)(lba >> 8));
     outb(ATA_REG(ATA_LBA_HIGH), (uint8_t)(lba >> 16));
-    outb(ATA_REG(ATA_DRIVE), 0xE0 | ((lba >> 24) & 0x0F));
+    outb(ATA_REG(ATA_DRIVE), 0xE0 | (ata_drive << 4) | ((lba >> 24) & 0x0F));
     outb(ATA_REG(ATA_COMMAND), ATA_CMD_WRITE_PIO);
     ata_wait_bsy();
     ata_wait_drq();

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -1,7 +1,6 @@
 #include "fs.h"
 #include "mem.h"
 #include "disk.h"
-#include "embedded_resources.h"
 #include <stddef.h>
 #include <stdint.h>
 
@@ -128,6 +127,7 @@ const char* fs_read_file(fs_entry* file){
     uint32_t sectors = (file->size + 511) / 512;
     char* buf = mem_alloc(sectors*512 + 1);
     if(!buf) return "";
+    ata_select_drive(1);
     for(uint32_t i=0;i<sectors;i++)
         ata_read_sector(file->lba + i, buf + i*512);
     buf[file->size] = 0;
@@ -138,6 +138,7 @@ void fs_save_file(fs_entry* file){
     if(!file || file->is_dir || file->lba==0 || !file->content)
         return;
     uint32_t sectors = (file->size + 511) / 512;
+    ata_select_drive(1);
     for(uint32_t i=0;i<sectors;i++)
         ata_write_sector(file->lba + i, file->content + i*512);
 }
@@ -160,61 +161,60 @@ void fs_init(void){
        kernel sizes.  This keeps the in-memory filesystem layout consistent
        with the values used by the bootloader and build script.
     */
+    /* Read root table from the second drive which stores external resources */
+    ata_select_drive(1);
+    uint32_t entry_count = 0;
     uint32_t root_sectors = 0;
-    uint32_t kernel_sectors = 0;
     {
         unsigned char buf[512];
         ata_read_sector(1, buf);
-        root_sectors   = ((uint32_t*)buf)[1];
-        kernel_sectors = ((uint32_t*)buf)[2];
+        entry_count = ((uint32_t*)buf)[0];
+        root_sectors = ((uint32_t*)buf)[1];
     }
-    /* Fallback to calculated values if the header looked empty */
-    if(root_sectors == 0 || kernel_sectors == 0){
-        uint32_t kernel_bytes = (uint32_t)&end - 0x1000;
-        kernel_sectors = (kernel_bytes + 511) / 512;
-        uint32_t entry_bytes = EMBEDDED_RESOURCE_COUNT * (32 + 4 + 4);
-        uint32_t table_bytes = 12 + entry_bytes;
-        root_sectors = (table_bytes + 511) / 512;
-    }
-
-    uint32_t cur_lba = 1 + root_sectors + kernel_sectors;
-
-    for(uint32_t i=0;i<EMBEDDED_RESOURCE_COUNT;i++){
-        const char* name = embedded_resources[i].name;
-        fs_entry* dir = &root_dir;
-        char part[32];
-        size_t pi=0;
-        for(size_t j=0;;j++){
-            char c = name[j];
-            if(c=='/' || c==0){
-                part[pi]=0;
-                if(c==0){
-                    fs_entry* f = fs_create_file(dir, part);
-                    if(f){
-                        f->lba = cur_lba;
-                        f->size = embedded_resources[i].size;
-                        f->content = (char*)embedded_resources[i].data;
-                        f->embedded = 1;
+    if(entry_count && root_sectors){
+        unsigned char* full = mem_alloc(root_sectors * 512);
+        if(full){
+            for(uint32_t i=0;i<root_sectors;i++)
+                ata_read_sector(1 + i, full + i*512);
+            unsigned char* table = full + 12; /* skip header */
+            for(uint32_t i=0;i<entry_count;i++){
+                char name[33];
+                for(int j=0;j<32;j++) name[j] = table[i*40 + j];
+                name[32]=0;
+                uint32_t lba = *(uint32_t*)(table + i*40 + 32);
+                uint32_t size = *(uint32_t*)(table + i*40 + 36);
+                fs_entry* dir = &root_dir;
+                char part[32];
+                size_t pi=0;
+                for(size_t j=0;;j++){
+                    char c = name[j];
+                    if(c=='/' || c==0){
+                        part[pi]=0;
+                        if(c==0){
+                            fs_entry* f = fs_create_file(dir, part);
+                            if(f){
+                                f->lba = lba;
+                                f->size = size;
+                                f->content = NULL;
+                                f->embedded = 0;
+                            }
+                            break;
+                        }else{
+                            fs_entry* sub = fs_find_subdir(dir, part);
+                            if(!sub)
+                                sub = fs_create_dir(dir, part);
+                            dir = sub;
+                            pi = 0;
+                        }
+                    }else if(pi < 31){
+                        part[pi++] = c;
                     }
-                    cur_lba += (embedded_resources[i].size + 511)/512;
-                    break;
-                }else{
-                    fs_entry* sub = fs_find_subdir(dir, part);
-                    if(!sub)
-                        sub = fs_create_dir(dir, part);
-                    dir = sub;
-                    pi = 0;
                 }
-            }else if(pi < 31){
-                part[pi++] = c;
             }
         }
     }
 
-    /* Ensure the resources directory exists even if no files were
-       embedded. This prevents the shell from reporting it missing
-       and allows users to add files later. */
+    /* Ensure resources directory exists */
     if(!fs_find_subdir(&root_dir, "resources"))
         fs_create_dir(&root_dir, "resources");
-
 }

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ python3 setup_bootloader.py
 ```
 
 If `mkisofs` is available an ISO named `OptrixOS.iso` is created. Otherwise the
-script outputs `disk.img` which can be run with:
+script outputs `boot.img` and `resources.img`. Run them with:
 
 ```bash
-qemu-system-x86_64 -hda disk.img
+qemu-system-x86_64 -hda boot.img -hdb resources.img
 ```
 
 ## Built-in terminal

--- a/Run_OptrixOS.bat
+++ b/Run_OptrixOS.bat
@@ -1,3 +1,3 @@
 @echo off
 
-qemu-system-x86_64 -cdrom OptrixOS.iso
+qemu-system-x86_64 -cdrom OptrixOS.iso -hdb resources.img


### PR DESCRIPTION
## Summary
- add ability to select ATA drive
- load resource files from secondary disk
- adjust build to create `boot.img` and `resources.img`
- update docs and run script

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_685458201b50832fab892610f4d14ead