### PR TITLE
Add external resource disk support

### DIFF
--- a/OptrixOS-Kernel/include/disk.h
+++ b/OptrixOS-Kernel/include/disk.h
@@ -2,6 +2,7 @@
 #define DISK_H
 #include <stdint.h>
 void ata_init(void);
+void ata_select(uint16_t base, int slave);
 int ata_detect(void);
 int ata_read_sector(uint32_t lba, void* buffer);
 int ata_write_sector(uint32_t lba, const void* buffer);

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -217,4 +217,52 @@ void fs_init(void){
     if(!fs_find_subdir(&root_dir, "resources"))
         fs_create_dir(&root_dir, "resources");
 
+    /* Load additional resources from secondary ATA drive (0x170) */
+    unsigned char hdr[512];
+    ata_select(0x170, 0);
+    ata_read_sector(0, hdr);
+    uint32_t ext_count = ((uint32_t*)hdr)[0];
+    uint32_t ext_root_sectors = ((uint32_t*)hdr)[1];
+    if(ext_count > 0 && ext_root_sectors > 0){
+        unsigned char* table = mem_alloc(ext_root_sectors * 512);
+        if(table){
+            for(uint32_t i=0;i<ext_root_sectors;i++)
+                ata_read_sector(1+i, table + i*512);
+            for(uint32_t i=0;i<ext_count;i++){
+                unsigned char* ent = table + i*(32+4+4);
+                char nbuf[33];
+                for(int k=0;k<32;k++) nbuf[k] = ent[k];
+                nbuf[32] = 0;
+                uint32_t lba = *(uint32_t*)(ent+32);
+                uint32_t size = *(uint32_t*)(ent+36);
+                fs_entry* dir = &root_dir;
+                char part[32];
+                size_t pi=0;
+                for(size_t j=0;;j++){
+                    char c = nbuf[j];
+                    if(c=='/' || c==0){
+                        part[pi]=0;
+                        if(c==0){
+                            fs_entry* f = fs_create_file(dir, part);
+                            if(f){
+                                f->lba = lba;
+                                f->size = size;
+                            }
+                            break;
+                        } else {
+                            fs_entry* sub = fs_find_subdir(dir, part);
+                            if(!sub)
+                                sub = fs_create_dir(dir, part);
+                            dir = sub;
+                            pi=0;
+                        }
+                    } else if(pi < 31){
+                        part[pi++] = c;
+                    }
+                }
+            }
+        }
+    }
+    ata_select(0x1F0, 0);
+
 }

--- a/README.md
+++ b/README.md
@@ -73,13 +73,19 @@ The following commands are implemented:
 
 
 ### Resources
-Files inside `OptrixOS-Kernel/resources` are packed onto the disk image
-under `/resources`. Subdirectories are included as well. Even if no
-resource files are present the `/resources` directory will still be
-created so it is always available from within the OS.
+Files inside `OptrixOS-Kernel/resources` are now stored on a separate
+disk image named `resources.img`. The bootable ISO no longer contains
+these files; instead the OS expects a second drive attached when
+running under the emulator. The filesystem loader looks for the
+resources on the secondary ATA channel and mounts them automatically.
 
-The build script copies this directory to the root of the ISO so any
-files placed there appear under `/resources` when the system boots.
+To include your own resource files simply place them in the
+`OptrixOS-Kernel/resources` directory before running the build script.
+Launch QEMU with the generated `resources.img` as an additional drive:
+
+```bash
+qemu-system-x86_64 -cdrom OptrixOS.iso -hdb resources.img
+```
 
 `setup_bootloader.py` resolves the resources directory using its own
 location so it can be invoked from any path and still include the files


### PR DESCRIPTION
## Summary
- create a second `resources.img` drive for resource files
- load resources from the secondary ATA channel
- expose `ata_select` to choose drive
- update build script and documentation

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_68545cb171d4832f840a807afd298e18