### PR TITLE
Improve disk setup and verification

### DIFF
--- a/OptrixOS-Kernel/include/disk.h
+++ b/OptrixOS-Kernel/include/disk.h
@@ -5,4 +5,5 @@ void ata_init(void);
 int ata_detect(void);
 int ata_read_sector(uint32_t lba, void* buffer);
 int ata_write_sector(uint32_t lba, const void* buffer);
+int ata_is_ssd(void);
 #endif

--- a/OptrixOS-Kernel/src/disk.c
+++ b/OptrixOS-Kernel/src/disk.c
@@ -9,6 +9,9 @@
 #define ATA_DRIVE 6
 #define ATA_COMMAND 7
 #define ATA_DATA 0
+#define ATA_CMD_IDENTIFY 0xEC
+#define ATA_IDENT_MODEL_START 27
+#define ATA_IDENT_MODEL_END 46
 
 static uint16_t ata_io_base = 0x1F0;
 #define ATA_REG(r) (ata_io_base + (r))
@@ -18,12 +21,43 @@ static uint16_t ata_io_base = 0x1F0;
 #define ATA_STATUS_BSY 0x80
 #define ATA_STATUS_DRQ 0x08
 
+static int ata_ssd = 0;
+
 static void ata_wait_bsy(void){
     while(inb(ATA_STATUS) & ATA_STATUS_BSY);
 }
 
 static void ata_wait_drq(void){
     while(!(inb(ATA_STATUS) & ATA_STATUS_DRQ));
+}
+
+static void ata_identify(void){
+    outb(ATA_REG(ATA_SECTOR_COUNT), 0);
+    outb(ATA_REG(ATA_LBA_LOW), 0);
+    outb(ATA_REG(ATA_LBA_MID), 0);
+    outb(ATA_REG(ATA_LBA_HIGH), 0);
+    outb(ATA_REG(ATA_DRIVE), 0);
+    outb(ATA_REG(ATA_COMMAND), ATA_CMD_IDENTIFY);
+    if(inb(ATA_STATUS) == 0) return;
+    ata_wait_bsy();
+    ata_wait_drq();
+    uint16_t id[256];
+    for(int i=0;i<256;i++)
+        id[i] = inw(ATA_REG(ATA_DATA));
+    char model[41];
+    int pos = 0;
+    for(int w=ATA_IDENT_MODEL_START; w<=ATA_IDENT_MODEL_END; w++){
+        model[pos++] = id[w] >> 8;
+        model[pos++] = id[w] & 0xFF;
+    }
+    model[40] = 0;
+    ata_ssd = 0;
+    for(int i=0; model[i]; i++){
+        if(model[i]=='S' && model[i+1]=='S' && model[i+2]=='D'){
+            ata_ssd = 1;
+            break;
+        }
+    }
 }
 
 int ata_detect(void){
@@ -40,6 +74,11 @@ int ata_detect(void){
 void ata_init(void){
     ata_detect();
     ata_wait_bsy();
+    ata_identify();
+}
+
+int ata_is_ssd(void){
+    return ata_ssd;
 }
 
 int ata_read_sector(uint32_t lba, void* buffer){

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -142,7 +142,6 @@ void fs_save_file(fs_entry* file){
 }
 
 void fs_init(void){
-    ata_init();
 
     root_dir.name="/";
     root_dir.is_dir=1;

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -218,7 +218,10 @@ static void execute(const char*line){
 void terminal_init(void){
     screen_clear();
 
-    if(ata_detect())
+    ata_init();
+    if(ata_is_ssd())
+        print("SSD drive detected\n");
+    else if(ata_detect())
         print("ATA drive detected\n");
     else
         print("No ATA drive found\n");

--- a/README.md
+++ b/README.md
@@ -36,11 +36,14 @@ python3 setup_bootloader.py
 ```
 
 If `mkisofs` is available an ISO named `OptrixOS.iso` is created. Otherwise the
-script outputs `disk.img` which can be run with:
+script outputs `ssd.img` which can be run with:
 
 ```bash
-qemu-system-x86_64 -hda disk.img
+qemu-system-x86_64 -hda ssd.img
 ```
+
+The OS expects this SSD image to be attached at boot so that all resources
+and verification data can be loaded from it.
 
 ## Built-in terminal
 
@@ -73,14 +76,14 @@ The following commands are implemented:
 
 
 ### Resources
-Files inside `OptrixOS-Kernel/resources` are packed onto the disk image
-under `/resources`. Subdirectories are included as well. Even if no
+Files inside `OptrixOS-Kernel/resources` are packed onto the SSD disk image
+`ssd.img` under `/resources`. Subdirectories are included as well. Even if no
 resource files are present the `/resources` directory will still be
 created so it is always available from within the OS.
 
-The build script now stores these files only inside the disk image. They
+The build script now stores these files only inside the SSD image. They
 are not copied into the ISO itself, so the running system loads them
-from the attached disk image under `/resources`.
+from the attached SSD image under `/resources`.
 
 The repository includes a file `resources/verification.bin` which is
 written to the disk image.  During boot the kernel checks this file and

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -35,11 +35,20 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 KERNEL_PROJECT_ROOT = os.path.join(SCRIPT_DIR, "OptrixOS-Kernel")
 OUTPUT_ISO = os.path.join(SCRIPT_DIR, "OptrixOS.iso")
 KERNEL_BIN = "OptrixOS-kernel.bin"
-DISK_IMG = "disk.img"
+DISK_IMG = "ssd.img"
 TMP_ISO_DIR = "_iso_tmp"
 OBJ_DIR = "_build_obj"
 EMBED_HEADER = os.path.join(KERNEL_PROJECT_ROOT, "include", "embedded_resources.h")
 EMBED_SOURCE = os.path.join(KERNEL_PROJECT_ROOT, "src", "embedded_resources.c")
+
+VERIFICATION_CONTENT = b"VERIFICATION_OK"
+
+def ensure_verification_file():
+    vf = os.path.join(KERNEL_PROJECT_ROOT, "resources", "verification.bin")
+    if not os.path.exists(vf) or open(vf, "rb").read() != VERIFICATION_CONTENT:
+        os.makedirs(os.path.dirname(vf), exist_ok=True)
+        with open(vf, "wb") as fh:
+            fh.write(VERIFICATION_CONTENT)
 
 tmp_files = []
 
@@ -301,7 +310,7 @@ def copy_tree_to_iso(tmp_iso_dir, proj_root):
 
     # Place disk image at ISO root
     if os.path.exists(DISK_IMG):
-        shutil.copy(DISK_IMG, os.path.join(tmp_iso_dir, "disk.img"))
+        shutil.copy(DISK_IMG, os.path.join(tmp_iso_dir, "ssd.img"))
 
 
 def make_iso_with_tree(tmp_iso_dir, iso_out):
@@ -316,7 +325,7 @@ def make_iso_with_tree(tmp_iso_dir, iso_out):
         MKISOFS_EXE,
         "-quiet",
         "-o", iso_out,
-        "-b", "disk.img",
+        "-b", "ssd.img",
         "-R", "-J", "-l",
         tmp_iso_dir
     ]
@@ -345,6 +354,7 @@ def cleanup():
 
 def main():
     print("Collecting all project source files...")
+    ensure_verification_file()
     resources = collect_resources()
     # Resources are stored on the disk image only. The kernel no longer embeds
     # the raw file data, so generate an empty resource table for compilation.


### PR DESCRIPTION
## Summary
- support SSD disk image in setup script
- detect SSD drives on boot
- load resources from `ssd.img`
- ensure verification file is present when building

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68546354331c832fb035815bbd4597c0