### PR TITLE
Add SSD driver and debugging features

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -14,13 +14,14 @@ kernel.bin: asm/kernel.asm asm/ports.asm src/screen.o src/keyboard.o src/termina
 	@gcc $(CFLAGS) -c src/fs.c -o src/fs.o
 	@gcc $(CFLAGS) -c src/driver.c -o src/driver.o
 	@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
-	@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
-	@gcc $(CFLAGS) -c src/disk.c -o src/disk.o
-        @gcc $(CFLAGS) -c src/resources_test.c -o src/resources_test.o
-        @gcc $(CFLAGS) -c src/embedded_resources.c -o src/embedded_resources.o
-	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
+@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
+@gcc $(CFLAGS) -c src/disk.c -o src/disk.o
+@gcc $(CFLAGS) -c src/ssd.c -o src/ssd.o
+@gcc $(CFLAGS) -c src/resources_test.c -o src/resources_test.o
+@gcc $(CFLAGS) -c src/embedded_resources.c -o src/embedded_resources.o
+@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
 src/screen.o src/keyboard.o src/terminal.o src/fs.o \
-src/driver.o src/mem.o src/kernel_main.o src/disk.o src/resources_test.o src/embedded_resources.o --oformat binary -o $@
+src/driver.o src/mem.o src/kernel_main.o src/disk.o src/ssd.o src/resources_test.o src/embedded_resources.o --oformat binary -o $@
 	
 disk.img: bootloader.bin kernel.bin
 	@cat bootloader.bin kernel.bin > $@

--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -5,6 +5,7 @@ ORG 0x7C00
 
 start:
     cli
+    mov [BOOT_DRIVE], dl
     xor ax, ax
     mov ds, ax
     mov es, ax

--- a/OptrixOS-Kernel/include/ssd.h
+++ b/OptrixOS-Kernel/include/ssd.h
@@ -1,0 +1,11 @@
+#ifndef SSD_H
+#define SSD_H
+#include <stdint.h>
+
+void ssd_init(void);
+int ssd_detect(void);
+int ssd_read_sector(uint32_t lba, void* buffer);
+int ssd_write_sector(uint32_t lba, const void* buffer);
+int ssd_is_present(void);
+
+#endif

--- a/OptrixOS-Kernel/src/ssd.c
+++ b/OptrixOS-Kernel/src/ssd.c
@@ -1,0 +1,22 @@
+#include "ssd.h"
+#include "disk.h"
+
+void ssd_init(void){
+    ata_init();
+}
+
+int ssd_detect(void){
+    return ata_detect();
+}
+
+int ssd_read_sector(uint32_t lba, void* buffer){
+    return ata_read_sector(lba, buffer);
+}
+
+int ssd_write_sector(uint32_t lba, const void* buffer){
+    return ata_write_sector(lba, buffer);
+}
+
+int ssd_is_present(void){
+    return ata_detect();
+}

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -3,6 +3,7 @@
 #include "screen.h"
 #include "fs.h"
 #include "disk.h"
+#include "ssd.h"
 #include "mem.h"
 #include "resources_test.h"
 #include <stdint.h>
@@ -95,6 +96,7 @@ static void cmd_shutdown(void);
 static void cmd_ver(void);
 static void cmd_whoami(void);
 static void cmd_banner(void);
+static void cmd_debug(void);
 
 static unsigned int uptime = 0;
 static fs_entry* current_dir;
@@ -109,7 +111,7 @@ static int streq(const char*a,const char*b){while(*a&&*b){if(*a!=*b) return 0;a+
 static int strprefix(const char*s,const char*p){while(*p){if(*s!=*p) return 0;s++;p++;}return 1;}
 
 static void cmd_help(void){
-    print("help clear cls echo about add mul dir cd pwd cat touch rm mv mkdir rmdir cp sync rand date uptime ver whoami banner shutdown\n");
+    print("help clear cls echo about add mul dir cd pwd cat touch rm mv mkdir rmdir cp sync rand date uptime ver whoami banner debug shutdown\n");
 }
 
 static void cmd_clear(void){screen_clear(); row=col=0;}
@@ -170,6 +172,12 @@ static void cmd_banner(void){
     if(f){print(fs_read_file(f));put_char('\n');}
 }
 
+static void cmd_debug(void){
+    print("Memory total: ");print_int(mem_total());print("\n");
+    print("Memory used:  ");print_int(mem_used());print("\n");
+    print("Memory free:  ");print_int(mem_free());print("\n");
+}
+
 /* Verify presence and contents of verification.bin */
 static void check_verification(void){
     const char *expected = "VERIFICATION_OK";
@@ -211,6 +219,7 @@ static void execute(const char*line){
     else if(streq(line,"ver")) cmd_ver();
     else if(streq(line,"whoami")) cmd_whoami();
     else if(streq(line,"banner")) cmd_banner();
+    else if(streq(line,"debug")) cmd_debug();
     else if(streq(line,"shutdown")||streq(line,"exit")) cmd_shutdown();
     else if(line[0]) print("Unknown\n");
 }
@@ -218,15 +227,18 @@ static void execute(const char*line){
 void terminal_init(void){
     screen_clear();
 
-    ata_init();
+    ssd_init();
     if(ata_is_ssd())
         print("SSD drive detected\n");
-    else if(ata_detect())
+    else if(ssd_detect())
         print("ATA drive detected\n");
     else
         print("No ATA drive found\n");
 
     fs_init();
+
+    print("Mem total: "); print_int(mem_total()); print(" bytes\n");
+    print("Mem free:  "); print_int(mem_free());  print(" bytes\n");
 
     /* Debug: list all files embedded from the resources directory */
     resources_test();

--- a/Run_OptrixOS.bat
+++ b/Run_OptrixOS.bat
@@ -1,3 +1,3 @@
 @echo off
 
-qemu-system-x86_64 -cdrom OptrixOS.iso
+qemu-system-x86_64 -hda ssd.img


### PR DESCRIPTION
## Summary
- add new `ssd` driver files
- add debug command and memory info output
- update build script for 32MB disk and copy resources to ISO
- adjust bootloader to capture boot drive and run from `ssd.img`

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_685464fb93c8832fae67e604f70fb861