### PR TITLE
Generate filesystem bit at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.bin
+filesystem.bit
 *.img
 *.o
 *.elf

--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -1,6 +1,10 @@
 BITS 16
 ORG 0x7C00
 
+%ifndef KERNEL_SECTORS
+%define KERNEL_SECTORS 1
+%endif
+
 
 
 start:
@@ -29,30 +33,13 @@ start:
     jmp .printloop
 .doneprint:
 
-    ; read first filesystem sector to obtain kernel size
-    mov bx, 0x0600    ; buffer for root sector
-    mov dl, [BOOT_DRIVE]
-    mov dh, 0
-    mov ah, 0x02
-    mov al, 1         ; read 1 sector
-    mov cx, 0x0002    ; CH=0, CL=2 (sector 2)
-    int 0x13
-    mov si, bx
-    mov ax, [si+4]    ; root sector count
-    mov [root_sectors], ax
-    mov ax, [si+8]    ; kernel sector count
-    mov [kernel_sectors], ax
-    mov ax, [root_sectors]
-    add ax, 2         ; boot sector + root sectors -> first kernel sector
-    mov [kernel_start], ax
-
-    ; load kernel using values read from the filesystem
+    ; load kernel directly (kernel follows boot sector)
     mov bx, 0x1000    ; ES:BX points to load address
     mov dl, [BOOT_DRIVE]
     mov dh, 0         ; head
     mov ah, 0x02      ; BIOS read disk
-    mov al, [kernel_sectors]
-    mov cx, [kernel_start]
+    mov al, KERNEL_SECTORS
+    mov cx, 0x0002
     int 0x13
 
     ; setup basic GDT for protected mode
@@ -91,10 +78,6 @@ gdt_end:
 gdt_desc:
     dw gdt_end - gdt_start - 1
     dd gdt_start
-
-root_sectors:   dw 0
-kernel_sectors: dw 0
-kernel_start:   dw 0
 
 BOOT_DRIVE: db 0
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ behaviour of the historic `fsboot` loader. When executed it:
 - Clears a portion of RAM before loading the kernel.
 - Prompts for a kernel path (the input is currently ignored but demonstrates
   the interface).
-- Loads the kernel from the disk image into memory at `0x1000`.
+- Loads the kernel from disk into memory at `0x1000`.
 - Initializes a simple GDT and switches the CPU to 32-bit protected mode.
 - Jumps to the kernel entry point.
 - Sets the classic 80x25 text mode and jumps directly to the kernel.
@@ -35,15 +35,11 @@ Build the bootable image with:
 python3 setup_bootloader.py
 ```
 
-If `mkisofs` or `genisoimage` is available an ISO named `OptrixOS.iso` is created.
-Otherwise the script outputs `ssd.img` which can be run with:
-
-```bash
-qemu-system-x86_64 -hda ssd.img
-```
-
-The OS expects this SSD image to be attached at boot so that all resources
-and verification data can be loaded from it.
+Running `python3 setup_bootloader.py` now produces `OptrixOS.iso` directly.
+During the build a `filesystem.bit` image is generated from the contents of
+`OptrixOS-Kernel/resources` and linked into the kernel. No disk image is
+created and the OS accesses files from this embedded binary rather than
+`ssd.img`.
 
 ## Built-in terminal
 
@@ -77,17 +73,13 @@ The following commands are implemented:
 
 
 ### Resources
-Files inside `OptrixOS-Kernel/resources` are packed onto the SSD disk image
-`ssd.img` under `/resources`. Subdirectories are included as well. Even if no
-resource files are present the `/resources` directory will still be
-created so it is always available from within the OS.
-
-The build script stores these files inside the SSD image and also copies the
-`resources` directory onto the ISO so that the running system can access them
-even without a writable disk image.
+Files inside `OptrixOS-Kernel/resources` are converted into `filesystem.bit`
+during the build. This binary contains the directory tree and file data and is
+linked into the kernel so the files are always available from within the OS
+without attaching a separate disk image.
 
 The repository includes a file `resources/verification.bin` which is
-written to the disk image.  During boot the kernel checks this file and
+included in `filesystem.bit`.  During boot the kernel checks this file and
 prints `verification.bin: TRUE` if it was found and its contents match the
 expected string `VERIFICATION_OK`.
 

--- a/Run_OptrixOS.bat
+++ b/Run_OptrixOS.bat
@@ -1,3 +1,3 @@
 @echo off
 
-qemu-system-x86_64 -hda ssd.img
+qemu-system-x86_64 -cdrom OptrixOS.iso


### PR DESCRIPTION
## Summary
- generate `filesystem.bit` from the resources folder and remove the tracked binary
- ignore `filesystem.bit` as a build artifact
- explain in README how `filesystem.bit` is created

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854682ebee0832f94e74b41190c3dbd