### PR TITLE
Fix bootloader to load kernel from ISO

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ python3 setup_bootloader.py
 ```
 
 Running `python3 setup_bootloader.py` now produces `OptrixOS.iso` directly.
+The script creates a `boot.img` containing the bootloader and kernel, which is
+used as the El Torito boot image so the loader can read the kernel from
+contiguous sectors.
 During the build a `filesystem.bit` image is generated from the contents of
 `OptrixOS-Kernel/resources` and linked into the kernel. No disk image is
 created and the OS accesses files from this embedded binary rather than


### PR DESCRIPTION
## Summary
- create `boot.img` combining bootloader and kernel
- use the boot image when making the ISO
- update build instructions

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68546ce2acec832fbd92c18da6bccd79