### PR TITLE
Fix build script disk size and diskfs build errors

### DIFF
--- a/OptrixOS-Kernel/src/diskfs.c
+++ b/OptrixOS-Kernel/src/diskfs.c
@@ -113,8 +113,6 @@ void diskfs_write_file(fs_entry* e, const char* data, uint32_t size){
     metas[idx].size = size;
     e->disk_start = start;
     e->disk_size = size;
-    save_metadata();
-}
     /* Persist current metadata state to disk */
     save_metadata();
 }

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Build the bootable image with:
 python3 setup_bootloader.py
 ```
 
-The build script now creates a 5GB disk image so the running system has ample
-space for files. The kernel includes a very small on-disk filesystem accessed via
-a basic ATA driver. Files created with shell commands persist across boots as
-they are written into this image.
+The build script now creates a ~100MB disk image so the running system has
+some space for test files. The kernel includes a very small on-disk filesystem
+accessed via a basic ATA driver. Files created with shell commands persist
+across boots as they are written into this image.
 
 If `mkisofs` is available an ISO named `OptrixOS.iso` is created. Otherwise the
 script outputs `disk.img` which can be run with:

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -102,7 +102,10 @@ def make_dynamic_img(boot_bin, kernel_bin, img_out):
         sys.exit(1)
     kern = open(kernel_bin, "rb").read()
     total = 512 + len(kern)
-    min_size = total + 5 * 1024 * 1024 * 1024  # kernel plus 5GB
+    # The previous implementation created a huge 5GB disk image which caused
+    # `mkisofs` to fail on systems using a 32bit build. A smaller default disk
+    # keeps the image ISO-friendly while still providing space for testing.
+    min_size = total + 100 * 1024 * 1024  # kernel plus 100MB
     img_size = roundup(total, 512)
     if img_size < min_size:
         img_size = min_size


### PR DESCRIPTION
## Summary
- shrink default disk image to 100MB so ISO creation works
- fix duplicate code in `diskfs.c`
- update README accordingly

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs.exe not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548c0170b8832f9935a5460fbf7123