### PR TITLE
Fix mkisofs boot image size error

### DIFF
--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -249,6 +249,7 @@ def make_iso_with_tree(tmp_iso_dir, iso_out):
         "-quiet",
         "-o", iso_out,
         "-b", "disk.img",
+        "-no-emul",
         "-R", "-J", "-l",
         tmp_iso_dir
     ]


### PR DESCRIPTION
## Summary
- create the ISO with mkisofs using `-no-emul` so large disk images work

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs.exe not found)*

------
https://chatgpt.com/codex/tasks/task_e_68548cc7e250832f9ae8012d0624d5bd