### PR TITLE
Fix mkisofs flag

### DIFF
--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -249,7 +249,7 @@ def make_iso_with_tree(tmp_iso_dir, iso_out):
         "-quiet",
         "-o", iso_out,
         "-b", "disk.img",
-        "-no-emul",
+        "-no-emul-boot",
         "-R", "-J", "-l",
         tmp_iso_dir
     ]


### PR DESCRIPTION
## Summary
- fix ISO creation by using `-no-emul-boot`

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_68548daa0004832f8ee2c6c61ad9f302