### PR TITLE
Fix ISO build for 100MB image

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -80,6 +80,13 @@ BOOT_DRIVE: db 0
 
 bootmsg: db 'Loading OptrixOS...',0
 
-    ; boot signature
+; Pad to MBR partition table at offset 440
+    times 440-($-$$) db 0
+    dd 0x12345678          ; disk signature
+    ; Single partition entry (active, starts at LBA 1)
+    db 0x80, 0x00, 0x02, 0x00, 0x0B, 0xFF, 0xFF, 0xFF
+    dd 0x00000001
+    dd 0x00032013          ; ~100MB
+    times 16*3 db 0        ; remaining partition slots
     times 510-($-$$) db 0
     dw 0xAA55

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ Build the bootable image with:
 python3 setup_bootloader.py
 ```
 
-If `mkisofs` is available an ISO named `OptrixOS.iso` is created. Otherwise the
-script outputs `disk.img` which can be run with:
+If `mkisofs` is available an ISO named `OptrixOS.iso` is created using the
+`-hard-disk-boot` option so the full 100&nbsp;MB disk image can be booted
+directly. Otherwise the script outputs `disk.img` which can be run with:
 
 ```bash
 qemu-system-x86_64 -hda disk.img

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -260,6 +260,7 @@ def make_iso_with_tree(tmp_iso_dir, iso_out):
         "-quiet",
         "-o", iso_out,
         "-b", "disk.img",
+        "-hard-disk-boot",
         "-R", "-J", "-l",
         tmp_iso_dir
     ]


### PR DESCRIPTION
## Summary
- embed an MBR partition table in `bootloader.asm`
- use `mkisofs -hard-disk-boot` in the build script
- document ISO creation with hard-disk boot in README

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_6854951f2b10832faa92b11f33e138db