### PR TITLE
Fix bootloader drive setup and support custom disk image size

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -12,6 +12,8 @@ start:
     mov es, ax
     mov ss, ax
     mov sp, 0x7C00
+    ; Preserve BIOS drive number for later disk reads
+    mov [BOOT_DRIVE], dl
 
     ; Set 80x25 text mode
     mov ax, 0x0003

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Build the bootable image with:
 python3 setup_bootloader.py
 ```
 
+Set the `DISK_FREE_MB` environment variable to override the default
+100&nbsp;MB of free space reserved in the generated disk image.
+
 If `mkisofs` is available an ISO named `OptrixOS.iso` is created using the
 `-hard-disk-boot` option so the full 100&nbsp;MB disk image can be booted
 directly. Otherwise the script outputs `disk.img` which can be run with:

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -298,8 +298,13 @@ def main():
     c_files = list(dict.fromkeys(c_files))
     print(f"Found {len(asm_files)} asm, {len(c_files)} c, {len(h_files)} h files.")
     boot_bin, kernel_bin = build_kernel(asm_files, c_files, out_bin=KERNEL_BIN)
-    # Create a disk image with at least 100MB free space for user files
-    make_dynamic_img(boot_bin, kernel_bin, DISK_IMG, free_space=100*1024*1024)
+    # Allow free space override via DISK_FREE_MB environment variable
+    free_mb_env = os.environ.get("DISK_FREE_MB")
+    try:
+        free_space = int(free_mb_env) * 1024 * 1024 if free_mb_env else 100*1024*1024
+    except ValueError:
+        free_space = 100*1024*1024
+    make_dynamic_img(boot_bin, kernel_bin, DISK_IMG, free_space=free_space)
     copy_tree_to_iso(TMP_ISO_DIR, KERNEL_PROJECT_ROOT)
     make_iso_with_tree(TMP_ISO_DIR, OUTPUT_ISO)
 


### PR DESCRIPTION
## Summary
- store BIOS boot drive number before reading sectors
- allow specifying free space via `DISK_FREE_MB` in build script
- document new environment variable

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_685496d252e8832f82e75d3d8f779ca1