### PR TITLE
Improve kernel loading with BIOS extended read

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -30,13 +30,10 @@ start:
     jmp .printloop
 .doneprint:
 
-    ; load kernel (assumes kernel starts at second sector)
-    mov bx, 0x1000    ; ES:BX points to load address
+    ; load kernel using BIOS extended read
     mov dl, [BOOT_DRIVE]
-    mov dh, 0         ; head
-    mov ah, 0x02      ; BIOS read disk
-    mov al, KERNEL_SECTORS
-    mov cx, 0x0002    ; CH=0, CL=2 (sector 2)
+    mov si, DAP
+    mov ah, 0x42
     int 0x13
 
     ; setup basic GDT for protected mode
@@ -77,6 +74,13 @@ gdt_desc:
     dd gdt_start
 
 BOOT_DRIVE: db 0
+
+DAP:
+    db 0x10, 0         ; size and reserved
+    dw KERNEL_SECTORS  ; number of sectors to read
+    dw 0x1000          ; offset to load kernel
+    dw 0x0000          ; segment
+    dq 1               ; starting LBA (sector 2)
 
 bootmsg: db 'Loading OptrixOS...',0
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ behaviour of the historic `fsboot` loader. When executed it:
 - Prompts for a kernel path (the input is currently ignored but demonstrates
   the interface).
 - Loads the kernel from the disk image into memory at `0x1000`.
+- Uses BIOS extended reads so kernels larger than 128&nbsp;KB load correctly.
 - Initializes a simple GDT and switches the CPU to 32-bit protected mode.
 - Jumps to the kernel entry point.
 - Sets the classic 80x25 text mode and jumps directly to the kernel.

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -210,6 +210,9 @@ def build_kernel(asm_files, c_files, out_bin):
 
     kernel_bytes = os.path.getsize(out_bin)
     sectors = roundup(kernel_bytes, 512) // 512
+    if sectors > 0xFFFF:
+        print(f"Error: kernel size {kernel_bytes} bytes exceeds loader limit")
+        sys.exit(1)
 
     boot_bin = "bootloader.bin"
     assemble(bootloader_src, boot_bin, fmt="bin", defines={"KERNEL_SECTORS": sectors})


### PR DESCRIPTION
## Summary
- handle kernels larger than 128KB with BIOS extended read
- document the new capability in the README
- fail the build if the kernel exceeds the loader's limits

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs.exe not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a25a7f58832f977f743915f1514f