### PR TITLE
Implement disk partition table

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -30,6 +30,11 @@ start:
     jmp .printloop
 .doneprint:
 
+    ; fetch kernel start LBA from first partition entry
+    mov bx, part1_entry
+    mov eax, [bx + 8]
+    mov [DAP + 8], eax
+
     ; load kernel using BIOS extended read
     mov dl, [BOOT_DRIVE]
     mov si, DAP
@@ -84,6 +89,16 @@ DAP:
 
 bootmsg: db 'Loading OptrixOS...',0
 
-    ; boot signature
-    times 510-($-$$) db 0
+    ; pad to partition table start (offset 0x1BE)
+    times 0x1BE-($-$$) db 0
+
+part1_entry:
+    times 16 db 0
+part2_entry:
+    times 16 db 0
+part3_entry:
+    times 16 db 0
+part4_entry:
+    times 16 db 0
+
     dw 0xAA55

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ behaviour of the historic `fsboot` loader. When executed it:
   the interface).
 - Loads the kernel from the disk image into memory at `0x1000`.
 - Uses BIOS extended reads so kernels larger than 128&nbsp;KB load correctly.
+- Locates the boot partition via the MBR partition table.
 - Initializes a simple GDT and switches the CPU to 32-bit protected mode.
 - Jumps to the kernel entry point.
 - Sets the classic 80x25 text mode and jumps directly to the kernel.
@@ -49,10 +50,10 @@ To boot from the ISO instead use:
 qemu-system-x86_64 -cdrom OptrixOS.iso
 ```
 
-`setup_bootloader.py` also creates a zero-filled 100&nbsp;MB image named
-`drive_c.img` that is packaged alongside `disk.img` in the ISO. The running
-kernel does not currently implement a block device driver so this file acts only
-as a placeholder for future storage experiments.
+`setup_bootloader.py` embeds a small MBR with two partitions. The first holds
+the kernel while the second is a 100&nbsp;MB region reserved for future storage.
+For convenience this second partition is also written out as `drive_c.img` and
+packaged with the ISO.
 
 ## Built-in terminal
 


### PR DESCRIPTION
## Summary
- make the bootloader read the first partition entry to locate the kernel
- pad the boot sector to include an MBR partition table
- create `disk.img` with two partitions (boot and data)
- document partition table support in README

## Testing
- `python3 -m py_compile setup_bootloader.py`
- `python3 setup_bootloader.py` *(fails: `mkisofs.exe not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854a7dc92f0832fa1962661598ab830