### PR TITLE
Add partition table support

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -5,7 +5,7 @@ all: disk.img
 bootloader.bin: asm/bootloader.asm
 	@nasm -f bin $< -o $@
 	
-kernel.bin: asm/kernel.asm asm/ports.asm src/screen.o src/keyboard.o src/terminal.o src/fs.o src/driver.o src/mem.o src/kernel_main.o
+kernel.bin: asm/kernel.asm asm/ports.asm src/screen.o src/keyboard.o src/terminal.o src/fs.o src/driver.o src/mem.o src/partition.o src/kernel_main.o
 	@nasm -f elf32 asm/kernel.asm -o kernel_asm.o
 	@nasm -f elf32 asm/ports.asm -o ports.o
 	@gcc $(CFLAGS) -c src/screen.c -o src/screen.o
@@ -13,11 +13,12 @@ kernel.bin: asm/kernel.asm asm/ports.asm src/screen.o src/keyboard.o src/termina
 	@gcc $(CFLAGS) -c src/terminal.c -o src/terminal.o
 	@gcc $(CFLAGS) -c src/fs.c -o src/fs.o
 	@gcc $(CFLAGS) -c src/driver.c -o src/driver.o
-	@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
-	@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
-	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
-	src/screen.o src/keyboard.o src/terminal.o src/fs.o \
-	src/driver.o src/mem.o src/kernel_main.o --oformat binary -o $@
+@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
+@gcc $(CFLAGS) -c src/partition.c -o src/partition.o
+@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
+@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
+src/screen.o src/keyboard.o src/terminal.o src/fs.o \
+src/driver.o src/mem.o src/partition.o src/kernel_main.o --oformat binary -o $@
 	
 disk.img: bootloader.bin kernel.bin
 	@cat bootloader.bin kernel.bin > $@

--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -80,6 +80,20 @@ BOOT_DRIVE: db 0
 
 bootmsg: db 'Loading OptrixOS...',0
 
+    ; pad up to partition table area (offset 0x1BE)
+    times 446-($-$$) db 0
+
+    ; simple two-partition MBR table
+    ; partition 1: boot (start LBA 1, 256 sectors)
+    db 0x80,0x00,0x02,0x00,0x0B,0x00,0x00,0x00
+    dd 0x00000001
+    dd 0x00000100
+    ; partition 2: data (start LBA 257, remaining sectors)
+    db 0x00,0x00,0x00,0x00,0x83,0x00,0x00,0x00
+    dd 0x00000101
+    dd 0x00000F00
+    ; remaining empty entries
+    times (16*4 - 16*2) db 0
+
     ; boot signature
-    times 510-($-$$) db 0
     dw 0xAA55

--- a/OptrixOS-Kernel/include/partition.h
+++ b/OptrixOS-Kernel/include/partition.h
@@ -1,0 +1,20 @@
+#ifndef PARTITION_H
+#define PARTITION_H
+#include <stdint.h>
+
+typedef struct {
+    uint8_t boot_indicator;
+    uint8_t start_head;
+    uint8_t start_sector;
+    uint8_t start_cylinder;
+    uint8_t system_id;
+    uint8_t end_head;
+    uint8_t end_sector;
+    uint8_t end_cylinder;
+    uint32_t start_lba;
+    uint32_t sectors;
+} partition_entry;
+
+void partition_parse(void* mbr, partition_entry* entries, int max_entries);
+
+#endif

--- a/OptrixOS-Kernel/include/terminal.h
+++ b/OptrixOS-Kernel/include/terminal.h
@@ -3,5 +3,7 @@
 
 void terminal_init(void);
 void terminal_run(void);
+void terminal_print(const char* text);
+void terminal_print_int(int n);
 
 #endif

--- a/OptrixOS-Kernel/src/kernel_main.c
+++ b/OptrixOS-Kernel/src/kernel_main.c
@@ -2,6 +2,7 @@
 #include "terminal.h"
 #include "driver.h"
 #include "mem.h"
+#include "partition.h"
 
 /* simple heap placed at 0x200000 for illustration */
 #define HEAP_BASE ((unsigned char*)0x200000)
@@ -13,5 +14,15 @@ void kernel_main(void) {
     driver_init_all();
 
     terminal_init();
+
+    partition_entry parts[2];
+    partition_parse((void*)0x7c00, parts, 2);
+    terminal_print("Partition1 LBA:");
+    terminal_print_int(parts[0].start_lba);
+    terminal_print("\n");
+    terminal_print("Partition2 LBA:");
+    terminal_print_int(parts[1].start_lba);
+    terminal_print("\n");
+
     terminal_run();
 }

--- a/OptrixOS-Kernel/src/partition.c
+++ b/OptrixOS-Kernel/src/partition.c
@@ -1,0 +1,19 @@
+#include "partition.h"
+#include <stdint.h>
+
+void partition_parse(void* mbr, partition_entry* entries, int max_entries) {
+    uint8_t* data = (uint8_t*)mbr;
+    for(int i=0;i<max_entries;i++) {
+        uint8_t* p = data + 0x1BE + i*16;
+        entries[i].boot_indicator = p[0];
+        entries[i].start_head = p[1];
+        entries[i].start_sector = p[2];
+        entries[i].start_cylinder = p[3];
+        entries[i].system_id = p[4];
+        entries[i].end_head = p[5];
+        entries[i].end_sector = p[6];
+        entries[i].end_cylinder = p[7];
+        entries[i].start_lba = (uint32_t)p[8] | ((uint32_t)p[9]<<8) | ((uint32_t)p[10]<<16) | ((uint32_t)p[11]<<24);
+        entries[i].sectors = (uint32_t)p[12] | ((uint32_t)p[13]<<8) | ((uint32_t)p[14]<<16) | ((uint32_t)p[15]<<24);
+    }
+}

--- a/OptrixOS-Kernel/src/terminal.c
+++ b/OptrixOS-Kernel/src/terminal.c
@@ -51,6 +51,14 @@ static void print_int(int n) {
     for(int j=i-1;j>=0;j--) put_char(buf[j]);
 }
 
+void terminal_print(const char* text){
+    print(text);
+}
+
+void terminal_print_int(int n){
+    print_int(n);
+}
+
 static void read_line(char *buf, size_t max) {
     size_t idx=0;
     while(1) {


### PR DESCRIPTION
## Summary
- embed simple MBR partition table in bootloader
- add partition parser and print detected partition LBAs
- expose terminal_print helpers
- compile new partition.c in build system

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs.exe not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b9aeb2cc832faeef8c756fd591c0