### PR TITLE
Fix bootloader multi-sector load

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -30,14 +30,36 @@ start:
     jmp .printloop
 .doneprint:
 
-    ; load kernel (assumes kernel starts at second sector)
-    mov bx, 0x1000    ; ES:BX points to load address
+    ; load kernel (handles multi-track loads)
+    xor ax, ax
+    mov es, ax
+    mov di, 0x1000    ; load address
+    mov si, 1         ; first kernel LBA sector
+    mov cx, KERNEL_SECTORS
+.load_loop:
+    mov ax, si        ; convert LBA -> CHS
+    mov bx, 18        ; sectors per track
+    xor dx, dx
+    div bx            ; ax = lba/18, dx = lba%18
+    mov cl, dl
+    inc cl
+    mov bx, 2         ; heads
+    xor dx, dx
+    div bx            ; ax = cylinder, dx = head
+    mov ch, al
+    mov dh, dl
+    mov bl, ah        ; high cyl bits
+    and bl, 0x03
+    shl bl, 6
+    or cl, bl
     mov dl, [BOOT_DRIVE]
-    mov dh, 0         ; head
-    mov ah, 0x02      ; BIOS read disk
-    mov al, KERNEL_SECTORS
-    mov cx, 0x0002    ; CH=0, CL=2 (sector 2)
+    mov bx, di
+    mov ah, 0x02
+    mov al, 1
     int 0x13
+    add di, 512
+    inc si
+    loop .load_loop
 
     ; setup basic GDT for protected mode
     lgdt [gdt_desc]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ behaviour of the historic `fsboot` loader. When executed it:
 - Prompts for a kernel path (the input is currently ignored but demonstrates
   the interface).
 - Loads the kernel from the disk image into memory at `0x1000`.
+  The bootloader now reads the kernel sector by sector so images
+  larger than a single track load correctly.
 - Initializes a simple GDT and switches the CPU to 32-bit protected mode.
 - Jumps to the kernel entry point.
 - Sets the classic 80x25 text mode and jumps directly to the kernel.


### PR DESCRIPTION
## Summary
- load the kernel sector by sector when reading from disk
- update README to document robust loader

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854bf3b6418832f8d7a57962ff31ad7