### PR TITLE
Fix boot drive detection

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -13,6 +13,8 @@ start:
     mov es, ax
     mov ss, ax
     mov sp, 0x7C00
+    ; preserve boot drive number provided in DL
+    mov [BOOT_DRIVE], dl
 
     ; Set 80x25 text mode
     mov ax, 0x0003


### PR DESCRIPTION
## Summary
- preserve BIOS boot drive to ensure disk read succeeds

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_6854c49001a4832fabbab61a23ef1246