### PR TITLE
Implement partitioned boot image

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ Build the bootable image with:
 python3 setup_bootloader.py
 ```
 
-The build now also creates a blank 100&nbsp;MB storage image named
-`drive_c.img`. The bootable ISO includes this image so the OS can
-access additional storage during development.
+The build script now creates a partitioned `disk.img` containing two
+partitions. The first partition holds the bootloader and kernel while
+the second is reserved for future user data. A separate 100&nbsp;MB storage
+image named `drive_c.img` is still produced so the OS can access
+additional storage during development.
 
 If `mkisofs` is available an ISO named `OptrixOS.iso` is created along with
 `drive_c.img`. Boot the system with:


### PR DESCRIPTION
## Summary
- overhaul bootloader to load kernel from the first partition using BIOS LBA
- embed partition table in boot sector
- update build system to create a disk image with boot/data partitions
- generate ISO with no‑emulation boot mode
- document new partitioned image in README

## Testing
- `python3 setup_bootloader.py`


------
https://chatgpt.com/codex/tasks/task_e_6854c5f87b24832f8adbe87feee73672