### PR TITLE
Add partitioned disk generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ script outputs `disk.img` which can be run with:
 qemu-system-x86_64 -hda disk.img
 ```
 
+`setup_bootloader.py` now produces a disk image with two partitions.  The first
+partition is marked bootable and sized at 200&nbsp;MB while the second holds the
+OS data and is 1&nbsp;GB in size.  Both partitions are formatted as `ext2`.
+
 ## Built-in terminal
 
 After boot the machine displays a plain text console. No graphics or windowing


### PR DESCRIPTION
## Summary
- create `make_partitioned_img` in build script
- produce bootable disk with a 200MB boot partition and 1GB OS partition
- update README with partitioned disk details

## Testing
- `python3 -m py_compile setup_bootloader.py`


------
https://chatgpt.com/codex/tasks/task_e_6854c93d1018832fb4cbb6c0a45cd5ac