### PR TITLE
Add Windows-friendly FAT32 disk builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ script outputs `disk.img` which can be run with:
 qemu-system-x86_64 -hda disk.img
 ```
 
+`setup_bootloader.py` now produces a disk image with two FAT32 partitions using
+only Python code.  The first partition is marked bootable and sized at
+200&nbsp;MB while the second holds the OS data and is 1&nbsp;GB in size.  Install
+`pyfatfs` with `pip install pyfatfs` if it is not already available.
+
 ## Built-in terminal
 
 After boot the machine displays a plain text console. No graphics or windowing


### PR DESCRIPTION
## Summary
- replace `dd` and `parted` usage with a pure Python solution
- create FAT32 partitions using `pyfatfs`
- document the new approach in the README

## Testing
- `python3 -m py_compile setup_bootloader.py`


------
https://chatgpt.com/codex/tasks/task_e_6854c93d1018832fb4cbb6c0a45cd5ac