### PR TITLE
Fix builder fallback and boot error

### DIFF
--- a/OptrixOS-Kernel/asm/bootloader.asm
+++ b/OptrixOS-Kernel/asm/bootloader.asm
@@ -77,6 +77,17 @@ start:
     jmp .search
 
 kernel_not_found:
+    mov si, kernel_fail_msg
+.fail_print:
+    lodsb
+    or al, al
+    jz .fail_done
+    mov ah, 0x0E
+    mov bh, 0
+    mov bl, 0x4F
+    int 0x10
+    jmp .fail_print
+.fail_done:
     jmp hang
 
 found_kernel:
@@ -164,6 +175,8 @@ KERNEL_SIZE: dd 0
 
 kernel_name: db 'KERNEL.BIN;1'
 kernel_name_len equ $ - kernel_name
+
+kernel_fail_msg: db 'Kernel not found!',0
 
 bootmsg: db 'Loading OptrixOS...',0
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,15 @@ The kernel runs entirely in text mode and provides a small shell interface.
 Use `python3 setup_bootloader.py` to assemble and link the boot files. The
 script builds a small custom kernel located in `OptrixOS-Kernel/` and produces
 `OptrixOS-kernel.bin`. A cross compiler (`i686-linux-gnu-gcc`/`ld`) is preferred,
-but if it is not installed the script will fall back to the system `gcc` and
-`ld` with `-m32`.
+but if it is not installed the script automatically falls back to the system
+`gcc`/`ld` with `-m32`.
+
+If the cross compiler is not in your `PATH` you can explicitly invoke the
+builder using the host tools like so:
+
+```bash
+CC=gcc LD=ld python3 setup_bootloader.py
+```
 
 
 

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -6,9 +6,34 @@ import stat
 
 # --- CONFIGURATION ---
 TOOLCHAIN_DIR = os.environ.get("TOOLCHAIN_DIR") or r"C:\\Users\\jaide\\Downloads\\i686-elf-tools-windows\\bin"
-CC = os.environ.get("CC") or os.path.join(TOOLCHAIN_DIR, "i686-elf-gcc.exe")
-LD = os.environ.get("LD") or os.path.join(TOOLCHAIN_DIR, "i686-elf-ld.exe")
-OBJDUMP = os.environ.get("OBJDUMP") or os.path.join(TOOLCHAIN_DIR, "i686-elf-objdump.exe")
+
+# Select cross compiler if available, otherwise fall back to host tools
+CC = os.environ.get("CC")
+LD = os.environ.get("LD")
+OBJDUMP = os.environ.get("OBJDUMP")
+
+if not CC:
+    cc_candidate = os.path.join(TOOLCHAIN_DIR, "i686-elf-gcc.exe")
+    if os.path.isfile(cc_candidate) or shutil.which(cc_candidate):
+        CC = cc_candidate
+    else:
+        CC = shutil.which("gcc") or "gcc"
+        print("[setup_bootloader] Using host GCC (cross compiler not found)")
+
+if not LD:
+    ld_candidate = os.path.join(TOOLCHAIN_DIR, "i686-elf-ld.exe")
+    if os.path.isfile(ld_candidate) or shutil.which(ld_candidate):
+        LD = ld_candidate
+    else:
+        LD = shutil.which("ld") or "ld"
+        print("[setup_bootloader] Using host LD (cross linker not found)")
+
+if not OBJDUMP:
+    objdump_candidate = os.path.join(TOOLCHAIN_DIR, "i686-elf-objdump.exe")
+    if os.path.isfile(objdump_candidate) or shutil.which(objdump_candidate):
+        OBJDUMP = objdump_candidate
+    else:
+        OBJDUMP = shutil.which("objdump") or "objdump"
 NASM = "nasm"
 
 CDRTOOLS_DIR = os.environ.get("CDRTOOLS_DIR") or r"C:\\Program Files (x86)\\cdrtools"


### PR DESCRIPTION
## Summary
- add automatic GCC/LD fallback to setup_bootloader
- update README with host-tool usage example
- show a descriptive message if the kernel cannot be found

## Testing
- `CC=gcc LD=ld python3 setup_bootloader.py`


------
https://chatgpt.com/codex/tasks/task_e_6854d46e627c832fa5f5c79812b58080