### PR TITLE
Fix mkisofs error in ISO builder

### DIFF
--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -278,6 +278,7 @@ def make_iso_with_tree(tmp_iso_dir, iso_out):
         "-quiet",
         "-o", iso_out,
         "-b", "disk.img",
+        "-no-emul-boot",
         "-R", "-J", "-l",
         tmp_iso_dir
     ]


### PR DESCRIPTION
## Summary
- ensure mkisofs uses hard disk image without floppy emulation

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_6854da0574e8832fbd4979bccdc6d4e8