### PR TITLE
Improve resource embedding

### DIFF
--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -86,8 +86,7 @@ void fs_write_file(fs_entry* file,const char* text){
     if(!file || file->is_dir)
         return;
     size_t len = fs_strlen(text);
-    if(len>255) len=255;
-    char* buf = mem_alloc(len+1);
+    char* buf = mem_alloc(len + 1);
     if(!buf) return;
     for(size_t i=0;i<len;i++) buf[i]=text[i];
     buf[len]='\0';

--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ script outputs `disk.img` which can be run with:
 qemu-system-x86_64 -hda disk.img
 ```
 
+### Resource files
+
+Any files placed inside `OptrixOS-Kernel/resources/` are automatically
+embedded into the in-memory filesystem when `setup_bootloader.py` is run.
+These resources can be viewed from the shell using commands like `dir` and
+`cat`. There is no practical size limit beyond available memory.
+
 ## Built-in terminal
 
 After boot the machine displays a plain text console. No graphics or windowing

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -129,19 +129,22 @@ def collect_source_files(rootdir):
     return asm_files, c_files, h_files
 
 # === ROOT FILE EMBEDDING ===
-ROOT_FILES = [
-    os.path.join(KERNEL_PROJECT_ROOT, "resources", "welcome.txt"),
-    os.path.join(KERNEL_PROJECT_ROOT, "resources", "logo.txt"),
-]
+ROOT_RESOURCES_DIR = os.path.join(KERNEL_PROJECT_ROOT, "resources")
+
+def list_resource_files():
+    files = []
+    if os.path.isdir(ROOT_RESOURCES_DIR):
+        for root, _, names in os.walk(ROOT_RESOURCES_DIR):
+            for n in names:
+                files.append(os.path.join(root, n))
+    return files
 
 ROOT_C = os.path.join(KERNEL_PROJECT_ROOT, "src", "root_files.c")
 ROOT_H = os.path.join(KERNEL_PROJECT_ROOT, "include", "root_files.h")
 
 def generate_root_files():
     entries = []
-    for f in ROOT_FILES:
-        if not os.path.isfile(f):
-            continue
+    for f in list_resource_files():
         rel = os.path.relpath(f, KERNEL_PROJECT_ROOT).replace("\\", "/")
         with open(f, "r", errors="ignore") as fh:
             data = fh.read().replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n")


### PR DESCRIPTION
## Summary
- automatically include all resources in the ISO
- remove 255-byte cap when writing files
- document how resource files are embedded

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_6854dec33948832fbcd2ff9b1a050cd0