### PR TITLE
Improve root FS generation

### DIFF
--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -86,8 +86,7 @@ void fs_write_file(fs_entry* file,const char* text){
     if(!file || file->is_dir)
         return;
     size_t len = fs_strlen(text);
-    if(len>255) len=255;
-    char* buf = mem_alloc(len+1);
+    char* buf = mem_alloc(len + 1);
     if(!buf) return;
     for(size_t i=0;i<len;i++) buf[i]=text[i];
     buf[len]='\0';

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Build the bootable image with:
 python3 setup_bootloader.py
 ```
 
+All files placed in the `OptrixOS-Kernel/resources` directory are
+automatically embedded into the initial RAM filesystem and will be
+available from the shell after booting. This allows adding arbitrary
+files without modifying the build scripts.
+
 If `mkisofs` is available an ISO named `OptrixOS.iso` is created. Otherwise the
 script outputs `disk.img` which can be run with:
 

--- a/setup_bootloader.py
+++ b/setup_bootloader.py
@@ -129,17 +129,23 @@ def collect_source_files(rootdir):
     return asm_files, c_files, h_files
 
 # === ROOT FILE EMBEDDING ===
-ROOT_FILES = [
-    os.path.join(KERNEL_PROJECT_ROOT, "resources", "welcome.txt"),
-    os.path.join(KERNEL_PROJECT_ROOT, "resources", "logo.txt"),
-]
+def collect_resource_files():
+    res_dir = os.path.join(KERNEL_PROJECT_ROOT, "resources")
+    files = []
+    for root, _dirs, filenames in os.walk(res_dir):
+        for f in filenames:
+            if f.startswith('.'):
+                continue
+            files.append(os.path.join(root, f))
+    return files
 
 ROOT_C = os.path.join(KERNEL_PROJECT_ROOT, "src", "root_files.c")
 ROOT_H = os.path.join(KERNEL_PROJECT_ROOT, "include", "root_files.h")
 
 def generate_root_files():
     entries = []
-    for f in ROOT_FILES:
+    files = collect_resource_files()
+    for f in files:
         if not os.path.isfile(f):
             continue
         rel = os.path.relpath(f, KERNEL_PROJECT_ROOT).replace("\\", "/")


### PR DESCRIPTION
## Summary
- embed any file found in `resources` during build
- remove artificial 255 byte limit when loading files
- document automatic resource embedding

## Testing
- `python3 setup_bootloader.py`

------
https://chatgpt.com/codex/tasks/task_e_6854e36a9ae0832f967e6a86e7af86f1