### PR TITLE
Integrate disk driver and clean kernel

### DIFF
--- a/OptrixOS-Kernel/src/kernel_main.c
+++ b/OptrixOS-Kernel/src/kernel_main.c
@@ -4,6 +4,7 @@
 #include "mem.h"
 #include "disk.h"
 #include "mbr.h"
+#include "vfs.h"
 
 /* simple heap placed at 0x200000 for illustration */
 #define HEAP_BASE ((unsigned char*)0x200000)
@@ -13,24 +14,21 @@ void kernel_main(void) {
     screen_init();
     mem_init(HEAP_BASE, HEAP_SIZE);
     driver_init_all();
-    /* create a simple in-memory disk and parse its MBR */
-    disk_t* d = disk_create(512*1024, 512);
-    uint8_t buf[512];
-    disk_read(d, 0, buf, 1);
-    mbr_part_entry parts[4];
-    if(mbr_parse(buf, parts))
-        partition_create(d, parts[0].start_lba, parts[0].sectors);
-    /* create a simple in-memory disk and partition */
-    disk_t* d = disk_create(512*1024, 512);
-    (void)partition_create(d, 0, d->size / d->sector_size);
 
-    /* create a simple in-memory disk and parse its MBR */
+    /* create a simple in-memory disk */
     disk_t* d = disk_create(512*1024, 512);
+    partition_t* part = NULL;
+
+    /* try to parse an MBR from the first sector */
     uint8_t buf[512];
-    disk_read(d, 0, buf, 1);
     mbr_part_entry parts[4];
-    if(mbr_parse(buf, parts))
-        partition_create(d, parts[0].start_lba, parts[0].sectors);
+    if(disk_read(d, 0, buf, 1) && mbr_parse(buf, parts)) {
+        part = partition_create(d, parts[0].start_lba, parts[0].sectors);
+    } else {
+        /* fallback to a single partition covering the disk */
+        part = partition_create(d, 0, d->size / d->sector_size);
+    }
+    (void)part; /* currently unused */
 
     terminal_init();
     terminal_run();


### PR DESCRIPTION
## Summary
- fix kernel_main to initialize only one in‑memory disk
- parse MBR if present and fall back to single partition
- include vfs header for future filesystem work

## Testing
- `python3 setup_bootloader.py` *(fails: mkisofs missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855d04ca2ec832fa0bc758211ed3f7a