### PR TITLE
Add modular directories and driver setup

### DIFF
--- a/OptrixOS-Kernel/Makefile
+++ b/OptrixOS-Kernel/Makefile
@@ -5,19 +5,34 @@ all: disk.img
 bootloader.bin: asm/bootloader.asm
 	@nasm -f bin $< -o $@
 	
-kernel.bin: asm/kernel.asm asm/ports.asm src/screen.o src/keyboard.o src/terminal.o src/fs.o src/driver.o src/mem.o src/kernel_main.o
+kernel.bin: asm/kernel.asm asm/ports.asm
 	@nasm -f elf32 asm/kernel.asm -o kernel_asm.o
 	@nasm -f elf32 asm/ports.asm -o ports.o
 	@gcc $(CFLAGS) -c src/screen.c -o src/screen.o
 	@gcc $(CFLAGS) -c src/keyboard.c -o src/keyboard.o
 	@gcc $(CFLAGS) -c src/terminal.c -o src/terminal.o
 	@gcc $(CFLAGS) -c src/fs.c -o src/fs.o
+	@gcc $(CFLAGS) -c src/disk.c -o src/disk.o
+	@gcc $(CFLAGS) -c src/root_files.c -o src/root_files.o
 	@gcc $(CFLAGS) -c src/driver.c -o src/driver.o
 	@gcc $(CFLAGS) -c src/mem.c -o src/mem.o
 	@gcc $(CFLAGS) -c src/kernel_main.c -o src/kernel_main.o
+	@gcc $(CFLAGS) -c ../drivers/keyboard_drv.c -o drivers_keyboard_drv.o
+	@gcc $(CFLAGS) -c ../fs/vfs_wrapper.c -o fs_vfs_wrapper.o
+	@gcc $(CFLAGS) -c ../hardware/timer.c -o hardware_timer.o
+	@gcc $(CFLAGS) -c ../io/serial.c -o io_serial.o
+	@gcc $(CFLAGS) -c ../libc/string.c -o libc_string.o
+	@gcc $(CFLAGS) -c ../misc/util.c -o misc_util.o
+	@gcc $(CFLAGS) -c ../shell/shell_entry.c -o shell_shell_entry.o
+	@gcc $(CFLAGS) -c ../sys/system.c -o sys_system.o
+	@gcc $(CFLAGS) -c ../system/init.c -o system_init.o
+	@gcc $(CFLAGS) -c ../kernel.c -o kernel.o
 	@ld -m elf_i386 -Ttext 0x1000 kernel_asm.o ports.o \
-	src/screen.o src/keyboard.o src/terminal.o src/fs.o \
-	src/driver.o src/mem.o src/kernel_main.o --oformat binary -o $@
+src/screen.o src/keyboard.o src/terminal.o src/fs.o src/disk.o \
+src/root_files.o src/driver.o src/mem.o src/kernel_main.o \
+drivers_keyboard_drv.o fs_vfs_wrapper.o hardware_timer.o \
+io_serial.o libc_string.o misc_util.o shell_shell_entry.o \
+sys_system.o system_init.o kernel.o --oformat binary -o $@
 	
 disk.img: bootloader.bin kernel.bin
 	@cat bootloader.bin kernel.bin > $@
@@ -26,4 +41,4 @@ run: disk.img
 	@qemu-system-i386 -drive format=raw,file=disk.img
 	
 clean:
-	@rm -f *.bin *.o disk.img src/*.o kernel_asm.o
+	@rm -f *.bin *.o disk.img src/*.o kernel_asm.o kernel.o

--- a/OptrixOS-Kernel/include/disk.h
+++ b/OptrixOS-Kernel/include/disk.h
@@ -1,0 +1,22 @@
+#ifndef DISK_H
+#define DISK_H
+#include <stddef.h>
+
+#define DISK_SIZE (100*1024*1024)
+#define PARTITION_COUNT 2
+#define BLOCK_SIZE 512
+
+typedef struct {
+    size_t start;
+    size_t size;
+} partition_t;
+
+void disk_init(void);
+partition_t* disk_get_part(int idx);
+int disk_part_count(void);
+void disk_write_bytes(size_t addr, const void* src, size_t len);
+void disk_read_bytes(size_t addr, void* dst, size_t len);
+void disk_write_block(partition_t* part, size_t block, const void* src);
+void disk_read_block(partition_t* part, size_t block, void* dst);
+
+#endif /* DISK_H */

--- a/OptrixOS-Kernel/include/driver.h
+++ b/OptrixOS-Kernel/include/driver.h
@@ -10,5 +10,6 @@ typedef struct {
 void driver_register(driver_t *drv);
 void driver_init_all(void);
 void driver_update_all(void);
+void driver_setup(void);
 
 #endif

--- a/OptrixOS-Kernel/src/disk.c
+++ b/OptrixOS-Kernel/src/disk.c
@@ -1,0 +1,51 @@
+#include "disk.h"
+#include "mem.h"
+#include <stdint.h>
+
+static unsigned char disk_data[DISK_SIZE];
+static partition_t partitions[PARTITION_COUNT];
+
+void disk_init(void){
+    /* simple two partition layout: half and half */
+    size_t half = DISK_SIZE/2;
+    partitions[0].start = 0;
+    partitions[0].size = half;
+    partitions[1].start = half;
+    partitions[1].size = DISK_SIZE - half;
+}
+
+partition_t* disk_get_part(int idx){
+    if(idx < 0 || idx >= PARTITION_COUNT)
+        return 0;
+    return &partitions[idx];
+}
+
+int disk_part_count(void){
+    return PARTITION_COUNT;
+}
+
+void disk_write_bytes(size_t addr, const void* src, size_t len){
+    if(addr + len > DISK_SIZE) return;
+    const unsigned char* s = src;
+    for(size_t i=0;i<len;i++)
+        disk_data[addr+i] = s[i];
+}
+
+void disk_read_bytes(size_t addr, void* dst, size_t len){
+    if(addr + len > DISK_SIZE) return;
+    unsigned char* d = dst;
+    for(size_t i=0;i<len;i++)
+        d[i] = disk_data[addr+i];
+}
+
+void disk_write_block(partition_t* part, size_t block, const void* src){
+    if(!part) return;
+    size_t addr = part->start + block * BLOCK_SIZE;
+    disk_write_bytes(addr, src, BLOCK_SIZE);
+}
+
+void disk_read_block(partition_t* part, size_t block, void* dst){
+    if(!part) return;
+    size_t addr = part->start + block * BLOCK_SIZE;
+    disk_read_bytes(addr, dst, BLOCK_SIZE);
+}

--- a/OptrixOS-Kernel/src/driver.c
+++ b/OptrixOS-Kernel/src/driver.c
@@ -5,6 +5,12 @@
 static driver_t *drivers[MAX_DRIVERS];
 static int driver_count = 0;
 
+extern driver_t keyboard_driver;
+
+void driver_setup(void){
+    driver_register(&keyboard_driver);
+}
+
 void driver_register(driver_t *drv) {
     if(driver_count < MAX_DRIVERS)
         drivers[driver_count++] = drv;

--- a/OptrixOS-Kernel/src/fs.c
+++ b/OptrixOS-Kernel/src/fs.c
@@ -1,10 +1,12 @@
 #include "fs.h"
 #include "mem.h"
+#include "disk.h"
 #include "root_files.h"
 #include <stddef.h>
 #include <stdint.h>
 
 static fs_entry root_dir;
+static partition_t* root_partition;
 
 static size_t fs_strlen(const char* s){ size_t l=0; while(s[l]) l++; return l; }
 
@@ -100,6 +102,8 @@ const char* fs_read_file(fs_entry* file){
 }
 
 void fs_init(void){
+    disk_init();
+    root_partition = disk_get_part(0);
     root_dir.name="/";
     root_dir.is_dir=1;
     root_dir.parent=NULL;

--- a/drivers/README.md
+++ b/drivers/README.md
@@ -1,0 +1,1 @@
+Placeholder for drivers

--- a/drivers/keyboard_drv.c
+++ b/drivers/keyboard_drv.c
@@ -1,0 +1,7 @@
+#include "../OptrixOS-Kernel/include/keyboard.h"
+#include "../OptrixOS-Kernel/include/driver.h"
+
+static void kb_init(void) {}
+static void kb_update(void) { keyboard_update(); }
+
+driver_t keyboard_driver = { "keyboard", kb_init, kb_update };

--- a/drivers/keyboard_drv.h
+++ b/drivers/keyboard_drv.h
@@ -1,0 +1,5 @@
+#ifndef KEYBOARD_DRV_H
+#define KEYBOARD_DRV_H
+#include "../OptrixOS-Kernel/include/driver.h"
+extern driver_t keyboard_driver;
+#endif

--- a/fs/README.md
+++ b/fs/README.md
@@ -1,0 +1,1 @@
+Placeholder for fs

--- a/fs/vfs_wrapper.c
+++ b/fs/vfs_wrapper.c
@@ -1,0 +1,9 @@
+#include "../OptrixOS-Kernel/include/fs.h"
+
+void vfs_init(void){
+    fs_init();
+}
+
+fs_entry* vfs_root(void){
+    return fs_get_root();
+}

--- a/fs/vfs_wrapper.h
+++ b/fs/vfs_wrapper.h
@@ -1,0 +1,6 @@
+#ifndef VFS_WRAPPER_H
+#define VFS_WRAPPER_H
+#include "../OptrixOS-Kernel/include/fs.h"
+void vfs_init(void);
+fs_entry* vfs_root(void);
+#endif

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -1,0 +1,1 @@
+Placeholder for hardware

--- a/hardware/timer.c
+++ b/hardware/timer.c
@@ -1,0 +1,4 @@
+#include <stdint.h>
+volatile unsigned int timer_ticks = 0;
+void timer_tick(void){ timer_ticks++; }
+unsigned int timer_get_ticks(void){ return timer_ticks; }

--- a/hardware/timer.h
+++ b/hardware/timer.h
@@ -1,0 +1,5 @@
+#ifndef TIMER_H
+#define TIMER_H
+void timer_tick(void);
+unsigned int timer_get_ticks(void);
+#endif

--- a/include/README.md
+++ b/include/README.md
@@ -1,0 +1,1 @@
+Placeholder for include

--- a/include/common.h
+++ b/include/common.h
@@ -1,0 +1,4 @@
+#ifndef COMMON_H
+#define COMMON_H
+#define ARRAY_SIZE(a) (sizeof(a)/sizeof((a)[0]))
+#endif

--- a/io/README.md
+++ b/io/README.md
@@ -1,0 +1,1 @@
+Placeholder for io

--- a/io/serial.c
+++ b/io/serial.c
@@ -1,0 +1,2 @@
+#include "../OptrixOS-Kernel/include/ports.h"
+void serial_write_char(char c){ outb(0x3F8, c); }

--- a/io/serial.h
+++ b/io/serial.h
@@ -1,0 +1,4 @@
+#ifndef SERIAL_H
+#define SERIAL_H
+void serial_write_char(char c);
+#endif

--- a/kernel.c
+++ b/kernel.c
@@ -1,0 +1,10 @@
+#include "system/init.h"
+#include "shell/shell_entry.h"
+
+/* Simple wrapper around existing kernel_main logic */
+void kernel_main(void);
+
+void kmain(void){
+    system_init();
+    shell_run();
+}

--- a/libc/README.md
+++ b/libc/README.md
@@ -1,0 +1,1 @@
+Placeholder for libc

--- a/libc/string.c
+++ b/libc/string.c
@@ -1,0 +1,4 @@
+#include "string.h"
+
+size_t ustrlen(const char* s){ size_t l=0; while(s[l]) l++; return l; }
+void ustrcpy(char* d, const char* s){ while((*d++ = *s++)); }

--- a/libc/string.h
+++ b/libc/string.h
@@ -1,0 +1,6 @@
+#ifndef USTRING_H
+#define USTRING_H
+#include <stddef.h>
+size_t ustrlen(const char* s);
+void ustrcpy(char* d, const char* s);
+#endif

--- a/misc/README.md
+++ b/misc/README.md
@@ -1,0 +1,1 @@
+Placeholder for misc

--- a/misc/util.c
+++ b/misc/util.c
@@ -1,0 +1,1 @@
+void util_beep(void){ /* placeholder */ }

--- a/misc/util.h
+++ b/misc/util.h
@@ -1,0 +1,4 @@
+#ifndef UTIL_H
+#define UTIL_H
+void util_beep(void);
+#endif

--- a/multicatcher.s
+++ b/multicatcher.s
@@ -1,0 +1,4 @@
+.global multicatcher
+multicatcher:
+    ; Placeholder assembly routine
+    ret

--- a/shell/README.md
+++ b/shell/README.md
@@ -1,0 +1,1 @@
+Placeholder for shell

--- a/shell/shell_entry.c
+++ b/shell/shell_entry.c
@@ -1,0 +1,2 @@
+#include "../OptrixOS-Kernel/include/terminal.h"
+void shell_run(void){ terminal_run(); }

--- a/shell/shell_entry.h
+++ b/shell/shell_entry.h
@@ -1,0 +1,4 @@
+#ifndef SHELL_ENTRY_H
+#define SHELL_ENTRY_H
+void shell_run(void);
+#endif

--- a/sys/README.md
+++ b/sys/README.md
@@ -1,0 +1,1 @@
+Placeholder for sys

--- a/sys/system.c
+++ b/sys/system.c
@@ -1,0 +1,2 @@
+#include "../OptrixOS-Kernel/include/driver.h"
+void system_idle(void){ driver_update_all(); }

--- a/sys/system.h
+++ b/sys/system.h
@@ -1,0 +1,4 @@
+#ifndef SYSTEM_H
+#define SYSTEM_H
+void system_idle(void);
+#endif

--- a/system/README.md
+++ b/system/README.md
@@ -1,0 +1,1 @@
+Placeholder for system

--- a/system/init.c
+++ b/system/init.c
@@ -1,0 +1,16 @@
+#include "../OptrixOS-Kernel/include/screen.h"
+#include "../OptrixOS-Kernel/include/mem.h"
+#include "../OptrixOS-Kernel/include/disk.h"
+#include "../OptrixOS-Kernel/include/fs.h"
+#include "../OptrixOS-Kernel/include/driver.h"
+#include "../OptrixOS-Kernel/include/terminal.h"
+
+void system_init(void){
+    screen_init();
+    mem_init((unsigned char*)0x200000, 64*1024);
+    disk_init();
+    fs_init();
+    driver_setup();
+    driver_init_all();
+    terminal_init();
+}

--- a/system/init.h
+++ b/system/init.h
@@ -1,0 +1,4 @@
+#ifndef SYSTEM_INIT_H
+#define SYSTEM_INIT_H
+void system_init(void);
+#endif


### PR DESCRIPTION
## Summary
- restructure kernel build to include new driver and helper modules
- expose driver setup and wrapper init functions
- update kernel entry to use new system initialization
- extend build script to gather sources from extra directories

## Testing
- `make -C OptrixOS-Kernel clean`
- `make -C OptrixOS-Kernel`


------
https://chatgpt.com/codex/tasks/task_e_6855d2936078832f81b3c09f420f5677